### PR TITLE
partial disassembly of bank0b by following pointers in Data_c651

### DIFF
--- a/src/constants/map_constants.asm
+++ b/src/constants/map_constants.asm
@@ -12,7 +12,7 @@ DEF GR_ISLAND  EQU $1
 	const MAP_LIGHTNING_CLUB_ENTRANCE     ; $06
 	const MAP_LIGHTNING_CLUB_LOBBY        ; $07
 	const MAP_LIGHTNING_CLUB_1            ; $08
-	const MAP_LIGHTNING_CLUB_2            ; $09
+	const MAP_LIGHTNING_CLUB_2            ; $09 - main club room after defeating GR
 	const MAP_PSYCHIC_CLUB_ENTRANCE       ; $0a
 	const MAP_PSYCHIC_CLUB_LOBBY          ; $0b
 	const MAP_PSYCHIC_CLUB                ; $0c

--- a/src/constants/var_constants.asm
+++ b/src/constants/var_constants.asm
@@ -3,7 +3,7 @@
 	const VAR_01 ; $01
 	const VAR_02 ; $02
 	const VAR_03 ; $03
-	const VAR_04 ; $04
+	const VAR_TIMES_RONALD_MET ; $04
 	const VAR_05 ; $05
 	const VAR_06 ; $06
 	const VAR_07 ; $07

--- a/src/constants/var_constants.asm
+++ b/src/constants/var_constants.asm
@@ -3,7 +3,7 @@
 	const VAR_01 ; $01
 	const VAR_02 ; $02
 	const VAR_03 ; $03
-	const VAR_TIMES_RONALD_MET ; $04
+	const VAR_TIMES_MET_RONALD ; $04
 	const VAR_05 ; $05
 	const VAR_06 ; $06
 	const VAR_07 ; $07

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -183,12 +183,12 @@ Func_c163:
 	ret
 
 Func_c169:
-	ld a, $0a
+	ld a, 10
 	call WaitAFrames
 	ret
 
 Func_c16f:
-	ld a, $0c
+	ld a, SFX_0C
 	call PlaySFX
 	ret
 
@@ -722,18 +722,18 @@ LoadNPCDuelistDeck:
 	ret
 
 ; return - a : number of coin pieces obtained
-CountGRCoinPieces:
+CountGRCoinPiecesObtained:
 	push bc
-	ld b, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT ; $0c
-	ld c, $00 ; counter for how many pieces obtained
-.loop ; loop 4 times, from $0c to $0f
+	ld b, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
+	ld c, 0 ; counter for how many pieces obtained
+.loop
 	ld a, b
 	call GetEventValue
-	jr z, .asm_c517
+	jr z, .not_obtained
 	inc c ; obtained this piece
-.asm_c517
+.not_obtained
 	ld a, b
-	cp EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT ; $0f
+	cp EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
 	jr z, .done
 	inc b
 	jr .loop

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -250,7 +250,9 @@ HandleStartMenu:
 	jr c, .no_saved_duel
 	ld hl, wd554
 	set 2, [hl]
-	ld a, VAR_04
+	; on second meeting, Ronald card pops with you
+	; and unlocks it in the start menu
+	ld a, VAR_TIMES_RONALD_MET
 	call GetVarValue
 	cp $02
 	jr c, .menu_config4
@@ -262,7 +264,7 @@ HandleStartMenu:
 	set 1, [hl]
 	jr .menu_config3
 .no_saved_duel
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	call GetVarValue
 	cp $02
 	jr c, .menu_config1
@@ -2219,7 +2221,7 @@ GeneralVarMasks:
 	db $01, %00000011 ; VAR_01
 	db $01, %00111100 ; VAR_02
 	db $01, %11000000 ; VAR_03
-	db $02, %00001111 ; VAR_04
+	db $02, %00001111 ; VAR_TIMES_RONALD_MET
 	db $03, %00000011 ; VAR_05
 	db $03, %00001100 ; VAR_06
 	db $03, %00110000 ; VAR_07

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -1227,7 +1227,7 @@ Func_d299::
 	ld a, $01
 	farcall Func_10413
 	ld b, $00
-	ld a, [wd58a]
+	ld a, [wCurMap]
 	ld c, a
 	farcall LoadOWMap
 	ld a, [wd58f]
@@ -1394,7 +1394,7 @@ Func_d421::
 	ld h, [hl]  ;
 	ld l, a
 	ld a, c
-	ld de, wd58a
+	ld de, wCurMap
 	ld bc, $5
 	call CopyFarHLToDE
 	ld a, [wd586]

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -181,50 +181,42 @@ Func_c163:
 	ld a, $00
 	ld [wd582], a
 	ret
-; 0xc169
 
 Func_c169:
 	ld a, $0a
 	call WaitAFrames
 	ret
-; 0xc16f
 
 Func_c16f:
 	ld a, $0c
 	call PlaySFX
 	ret
-; 0xc175
 
 Func_c175:
 	ld a, [wNextMusic]
 	farcall PlayAfterCurrentSong
 	ret
-; 0xc17d
 
 Func_c17d:
 	ld a, $01
 	call Func_338f
 	ret
-; 0xc183
 
 Func_c183:
 	ld a, $01
 	call Func_33a3
 	ret
-; 0xc189
 
 Func_c189:
 	ld a, $00
 	ld [wd582], a
 	ret
-; 0xc18f
 
 Func_c18f:
 	farcall PlayCurrentSong
 	ld a, $00
 	ld [wd582], a
 	ret
-; 0xc199
 
 Func_c199:
 	ld a, $00
@@ -1012,7 +1004,7 @@ Data_c651::
 	dba Data_2da26 ; $11
 	dba Data_2dc9f ; $12
 	dba Data_2e06d ; $13
-	dbw $0f, $4ee6 ; 
+	dbw $0f, $4ee6 ;
 	dba Data_2e163 ; $15
 	dba Data_2e4b7 ; $16
 	dba Data_2e63f ; $17

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -1451,7 +1451,7 @@ SetOWObjectTargetPosition:
 	ld b, WEST
 .got_x_dir
 	ld a, [wd595]
-	farcall SetOWObjectDirection
+	farcall _SetOWObjectDirection
 	ld a, 1
 	ld [wOWObjYVelocity], a
 	ld a, [wOWObjTargetY]
@@ -1502,7 +1502,7 @@ SetOWObjectTargetPosition:
 	ld b, NORTH
 .got_y_dir
 	ld a, [wd595]
-	farcall SetOWObjectDirection
+	farcall _SetOWObjectDirection
 	ld a, 1
 	ld [wOWObjXVelocity], a
 	ld a, [wOWObjTargetX]

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -196,7 +196,7 @@ Func_c16f:
 ; 0xc175
 
 Func_c175:
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	farcall PlayAfterCurrentSong
 	ret
 ; 0xc17d

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -244,7 +244,7 @@ HandleStartMenu:
 	set 2, [hl]
 	; on second meeting, Ronald card pops with you
 	; and unlocks it in the start menu
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	call GetVarValue
 	cp $02
 	jr c, .menu_config4
@@ -256,7 +256,7 @@ HandleStartMenu:
 	set 1, [hl]
 	jr .menu_config3
 .no_saved_duel
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	call GetVarValue
 	cp $02
 	jr c, .menu_config1
@@ -2213,7 +2213,7 @@ GeneralVarMasks:
 	db $01, %00000011 ; VAR_01
 	db $01, %00111100 ; VAR_02
 	db $01, %11000000 ; VAR_03
-	db $02, %00001111 ; VAR_TIMES_RONALD_MET
+	db $02, %00001111 ; VAR_TIMES_MET_RONALD
 	db $03, %00000011 ; VAR_05
 	db $03, %00001100 ; VAR_06
 	db $03, %00110000 ; VAR_07

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -727,22 +727,23 @@ LoadNPCDuelistDeck:
 	pop bc
 	ret
 
-Func_c50b:
+; return - a : number of coin pieces obtained
+CountGRCoinPieces:
 	push bc
-	ld b, $0c
-	ld c, $00
-.asm_c510
+	ld b, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT ; $0c
+	ld c, $00 ; counter for how many pieces obtained
+.loop ; loop 4 times, from $0c to $0f
 	ld a, b
 	call GetEventValue
 	jr z, .asm_c517
-	inc c
+	inc c ; obtained this piece
 .asm_c517
 	ld a, b
-	cp $0f
-	jr z, .asm_c51f
+	cp EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT ; $0f
+	jr z, .done
 	inc b
-	jr .asm_c510
-.asm_c51f
+	jr .loop
+.done
 	ld a, c
 	pop bc
 	ret

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -177,6 +177,62 @@ Func_c12e::
 Func_c162:
 	ret
 
+Func_c163:
+	ld a, $00
+	ld [wd582], a
+	ret
+; 0xc169
+
+Func_c169:
+	ld a, $0a
+	call WaitAFrames
+	ret
+; 0xc16f
+
+Func_c16f:
+	ld a, $0c
+	call PlaySFX
+	ret
+; 0xc175
+
+Func_c175:
+	ld a, [wd58e]
+	farcall PlayAfterCurrentSong
+	ret
+; 0xc17d
+
+Func_c17d:
+	ld a, $01
+	call Func_338f
+	ret
+; 0xc183
+
+Func_c183:
+	ld a, $01
+	call Func_33a3
+	ret
+; 0xc189
+
+Func_c189:
+	ld a, $00
+	ld [wd582], a
+	ret
+; 0xc18f
+
+Func_c18f:
+	farcall PlayCurrentSong
+	ld a, $00
+	ld [wd582], a
+	ret
+; 0xc199
+
+Func_c199:
+	ld a, $00
+	ld [wd582], a
+	call Func_32f6
+	ret
+; 0xc1a2
+
 SECTION "Bank 3@41c9", ROMX[$41c9], BANK[$3]
 
 HandleStartMenu:
@@ -670,9 +726,26 @@ LoadNPCDuelistDeck:
 	pop de
 	pop bc
 	ret
-; 0xc50b
 
-SECTION "Bank 3@4522", ROMX[$4522], BANK[$3]
+Func_c50b:
+	push bc
+	ld b, $0c
+	ld c, $00
+.asm_c510
+	ld a, b
+	call GetEventValue
+	jr z, .asm_c517
+	inc c
+.asm_c517
+	ld a, b
+	cp $0f
+	jr z, .asm_c51f
+	inc b
+	jr .asm_c510
+.asm_c51f
+	ld a, c
+	pop bc
+	ret
 
 ; return the location name in hl, using c == island and a == location
 GetLocationName:
@@ -922,40 +995,40 @@ Data_c651::
 	dbw $10, $4db3 ; $02
 	dbw $0f, $4603 ; $03
 	dbw $0f, $47dc ; $04
-	dbw $0b, $4000 ; $05
+	dba Data_2c000 ; $05
 	dbw $0f, $4b88 ; $06
 	dbw $0f, $4c62 ; $07
-	dbw $0b, $4479 ; $08
-	dbw $0b, $4936 ; $09
-	dbw $0b, $4afa ; $0a
-	dbw $0b, $4d23 ; $0b
-	dbw $0b, $530a ; $0c
-	dbw $0b, $53c4 ; $0d
-	dbw $0b, $55f8 ; $0e
-	dbw $0b, $5930 ; $0f
-	dbw $0b, $5a26 ; $10
-	dbw $0b, $5c9f ; $11
-	dbw $0b, $606d ; $12
-	dbw $0f, $4ee6 ; $13
-	dbw $0b, $6163 ; $14
-	dbw $0b, $64b7 ; $15
-	dbw $0b, $663f ; $16
-	dbw $0b, $68e6 ; $17
-	dbw $0b, $6cc8 ; $18
-	dbw $0b, $6dc5 ; $19
-	dbw $0b, $7012 ; $1a
-	dbw $0b, $74ff ; $1b
-	dbw $0b, $75fc ; $1c
-	dbw $0b, $77ca ; $1d
-	dbw $0d, $4575 ; $1e
-	dbw $0d, $4773 ; $1f
-	dbw $0f, $519e ; $20
-	dbw $0f, $52d7 ; $21
-	dbw $10, $5592 ; $22
-	dbw $0b, $7cd5 ; $23
-	dbw $0f, $55d1 ; $24
-	dbw $0f, $5d58 ; $25
-	dbw $0b, $7e45 ; $26
+	dba Data_2c479 ; $08
+	dba Data_2c936 ; $0a - not sure why $09 is skipped, but the data this points to is definitely $0a
+	dba Data_2cafa ; $0b
+	dba Data_2cd23 ; $0c
+	dba Data_2d30a ; $0d
+	dba Data_2d3c4 ; $0e
+	dba Data_2d5f8 ; $0f
+	dba Data_2d930 ; $10
+	dba Data_2da26 ; $11
+	dba Data_2dc9f ; $12
+	dba Data_2e06d ; $13
+	dbw $0f, $4ee6 ; 
+	dba Data_2e163 ; $15
+	dba Data_2e4b7 ; $16
+	dba Data_2e63f ; $17
+	dba Data_2e8e6 ; $18
+	dba Data_2ecc8 ; $19
+	dba Data_2edc5 ; $1a
+	dba Data_2f012 ; $1b
+	dba Data_2f4ff ; $1c
+	dba Data_2f5fc ; $1d
+	dba Data_2f7ca ; $1e
+	dbw $0d, $4575 ; $
+	dbw $0d, $4773 ; $
+	dbw $0f, $519e ; $
+	dbw $0f, $52d7 ; $
+	dbw $10, $5592 ; $
+	dba Data_2fcd5 ; $24
+	dbw $0f, $55d1 ; $
+	dbw $0f, $5d58 ; $
+	dba Data_2fe45 ; $26
 	dbw $0d, $4aaf ; $27
 	dbw $10, $5be9 ; $28
 	dbw $0f, $6698 ; $29

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1747,6 +1747,7 @@ LoadOWObjectInMap::
 ; 0x10da3
 
 SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
+
 _ClearOWObject:
 	call ClearOWObject
 	ret

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1708,11 +1708,11 @@ Func_10d40::
 
 SECTION "Bank 4@4d50", ROMX[$4d50], BANK[$4]
 
-Func_10d50:
+GetOWObjectWithIDWrapper:
 	call GetOWObjectWithID
 	ret
 
-Func_10d54:
+GetOWObjectSpriteAnimWrapper:
 	call GetOWObjectSpriteAnim
 	ret
 
@@ -1763,7 +1763,7 @@ Func_10da7::
 	push af
 	push hl
 	call GetOWObjectWithID
-	call Func_10d54
+	call GetOWObjectSpriteAnimWrapper
 	call GetSpriteAnimPosition
 	call Func_10b81
 	pop hl
@@ -1775,7 +1775,7 @@ Func_10db8:
 	push de
 	push hl
 	call GetOWObjectWithID
-	call Func_10d54
+	call GetOWObjectSpriteAnimWrapper
 	call Func_10d5c
 	call SetSpriteAnimPosition
 	pop hl
@@ -1788,7 +1788,9 @@ Func_10dcb::
 	call Func_112b2
 	ret
 
-Func_10dcf::
+; a = OW_* constant (ow_object)
+; b = direction
+SetOWObjectDirectionWrapper::
 	call SetOWObjectDirection
 	ret
 
@@ -1889,7 +1891,7 @@ Func_10e3c::
 	xor a
 	ld [wd98a], a
 	ld a, [wd989]
-	call Func_10d50
+	call GetOWObjectWithIDWrapper
 	bit 5, [hl] ; OWOBJSTRUCT_FLAGS
 	jr z, .asm_10e8f
 	call Func_10da7
@@ -2022,7 +2024,7 @@ Func_10ed3:
 
 Func_10eff::
 	push hl
-	call Func_10d50
+	call GetOWObjectWithIDWrapper
 	set 5, [hl] ; OWOBJSTRUCT_FLAGS
 	pop hl
 	ret
@@ -2705,6 +2707,7 @@ Func_112b2:
 	pop af
 	ret
 
+; a = OW_* constant (ow_object)
 ; b = direction
 SetOWObjectDirection:
 	push af

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1748,8 +1748,8 @@ LoadOWObjectInMap::
 
 SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
 
-_ClearOWObject:
-	call ClearOWObject
+ClearOWObject:
+	call _ClearOWObject
 	ret
 
 Func_10da7::
@@ -2651,7 +2651,7 @@ LoadOWObject:
 	farcall _LoadOWObject
 	ret
 
-ClearOWObject:
+_ClearOWObject:
 	push af
 	push hl
 	call GetOWObjectWithID

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1685,8 +1685,8 @@ GetOWObjectWithIDWrapper:
 	call GetOWObjectWithID
 	ret
 
-GetOWObjectSpriteAnimWrapper:
-	call GetOWObjectSpriteAnim
+GetOWObjectSpriteAnim:
+	call _GetOWObjectSpriteAnim
 	ret
 
 GetOWObjectSpriteAnimFlags::
@@ -1747,7 +1747,7 @@ LoadOWObjectInMap::
 ; 0x10da3
 
 SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
-ClearOWObjectWrapper:
+_ClearOWObject:
 	call ClearOWObject
 	ret
 
@@ -1755,7 +1755,7 @@ Func_10da7::
 	push af
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnimWrapper
+	call GetOWObjectSpriteAnim
 	call GetSpriteAnimPosition
 	call Func_10b81
 	pop hl
@@ -1767,7 +1767,7 @@ Func_10db8:
 	push de
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnimWrapper
+	call GetOWObjectSpriteAnim
 	call Func_10d5c
 	call SetSpriteAnimPosition
 	pop hl
@@ -1781,8 +1781,8 @@ Func_10dcb::
 
 ; a = OW_* constant (ow_object)
 ; b = direction
-SetOWObjectDirectionWrapper::
-	call SetOWObjectDirection
+SetOWObjectDirection::
+	call _SetOWObjectDirection
 	ret
 
 Func_10dd3::
@@ -2602,7 +2602,7 @@ GetOWObjectWithID:
 	pop af
 	ret
 
-GetOWObjectSpriteAnim:
+_GetOWObjectSpriteAnim:
 	push af
 	inc hl
 	inc hl
@@ -2621,7 +2621,7 @@ _GetOWObjectSpriteAnimFlags:
 	srl b
 	srl b
 	srl b
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	ld a, [hl]
 	and $f0
 	or b
@@ -2657,7 +2657,7 @@ ClearOWObject:
 	xor a
 	ld [hli], a ; OWOBJSTRUCT_FLAGS
 	ld [hld], a ; OWOBJSTRUCT_ID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10b71
 	pop hl
 	pop af
@@ -2667,7 +2667,7 @@ GetOWObjectPosition:
 	push af
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call GetSpriteAnimPosition
 	call ConvertToOWObjectPosition
 	pop hl
@@ -2680,7 +2680,7 @@ SetOWObjectPosition:
 	push de
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call ConvertToSpriteAnimPosition
 	call SetSpriteAnimPosition
 	pop hl
@@ -2692,7 +2692,7 @@ Func_112b2:
 	push af
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10a5c
 	pop hl
 	pop af
@@ -2700,12 +2700,12 @@ Func_112b2:
 
 ; a = OW_* constant (ow_object)
 ; b = direction
-SetOWObjectDirection:
+_SetOWObjectDirection:
 	push af
 	push bc
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call SetSpriteAnimDirection
 	pop hl
 	pop bc
@@ -2715,7 +2715,7 @@ SetOWObjectDirection:
 SetOWObjectSpriteAnimating:
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call SetSpriteAnimAnimating
 	pop hl
 	ret
@@ -2723,7 +2723,7 @@ SetOWObjectSpriteAnimating:
 ResetOWObjectSpriteAnimating:
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call ResetSpriteAnimAnimating
 	pop hl
 	ret
@@ -2731,7 +2731,7 @@ ResetOWObjectSpriteAnimating:
 Func_112e8:
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10abc
 	pop hl
 	ret
@@ -2739,7 +2739,7 @@ Func_112e8:
 Func_112f4:
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10ab9
 	pop hl
 	ret
@@ -2748,7 +2748,7 @@ Func_11300:
 	push af
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10a83
 	pop hl
 	pop af
@@ -2760,7 +2760,7 @@ Func_1130e:
 	push de
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10a94
 	pop hl
 	pop de
@@ -2772,7 +2772,7 @@ Func_11320:
 	push af
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10aa8
 	pop hl
 	pop af
@@ -2786,7 +2786,7 @@ Func_1132e:
 	push de
 	push hl
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	bit SPRITEANIMSTRUCT_MOVE_F, [hl]
 	jr nz, .done
 	bit 7, b
@@ -2836,7 +2836,7 @@ Func_11384::
 	bit 6, [hl] ; OWOBJSTRUCT_FLAGS
 	jr z, .next
 	push hl
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	bit SPRITEANIMSTRUCT_MOVE_F, [hl]
 	pop hl
 	jr nz, .next ; is moving
@@ -2984,7 +2984,7 @@ Func_11424:
 SetOWObjectAsScrollTarget:
 	ld [wScrollTargetObject], a
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call StoreScrollTargetObjectPtr
 	ret
 ; 0x1145d
@@ -2993,7 +2993,7 @@ SECTION "Bank 4@5471", ROMX[$5471], BANK[$4]
 
 Func_11471:
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call Func_10d17
 	ret
 ; 0x1147b
@@ -3002,7 +3002,7 @@ SECTION "Bank 4@5485", ROMX[$5485], BANK[$4]
 
 SetOWObjectFrameset:
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	call SetAndInitSpriteAnimFrameset
 	ret
 ; 0x1148f
@@ -3011,7 +3011,7 @@ SECTION "Bank 4@5499", ROMX[$5499], BANK[$4]
 
 SetOWObjectFrameDuration:
 	call GetOWObjectWithID
-	call GetOWObjectSpriteAnim
+	call _GetOWObjectSpriteAnim
 	ld a, c
 	call SetSpriteAnimFrameDuration
 	ret

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1671,7 +1671,7 @@ Func_10d5c:
 	ret
 ; 0x10d77
 SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
-Func_10da3:
+ClearOWObjectWrapper:
 	call ClearOWObject
 	ret
 ; 0x10da7

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1650,6 +1650,33 @@ Func_10cfe:
 	ret
 ; 0x10cff
 
+SECTION "Bank 4@4d5c", ROMX[$4d5c], BANK[$4]
+Func_10d5c:
+	push af
+	ld a, d
+	sla a
+	sla a
+	sla a
+	sla a
+	add $08
+	ld d, a
+	ld a, e
+	sla a
+	sla a
+	sla a
+	sla a
+	add $10
+	ld e, a
+	pop af
+	ret
+; 0x10d77
+SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
+Func_10da3:
+	call ClearOWObject
+	ret
+; 0x10da7
+
+
 SECTION "Bank 4@4d17", ROMX[$4d17], BANK[$4]
 
 Func_10d17:
@@ -1742,9 +1769,20 @@ Func_10da7::
 	pop hl
 	pop af
 	ret
-; 0x10db8
 
-SECTION "Bank 4@4dcb", ROMX[$4dcb], BANK[$4]
+Func_10db8:
+	push af
+	push de
+	push hl
+	call GetOWObjectWithID
+	call Func_10d54
+	call Func_10d5c
+	call SetSpriteAnimPosition
+	pop hl
+	pop de
+	pop af
+	ret
+; 0x10dcb
 
 Func_10dcb::
 	call Func_112b2

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1774,7 +1774,6 @@ Func_10db8:
 	pop de
 	pop af
 	ret
-; 0x10dcb
 
 Func_10dcb::
 	call Func_112b2

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -1650,33 +1650,6 @@ Func_10cfe:
 	ret
 ; 0x10cff
 
-SECTION "Bank 4@4d5c", ROMX[$4d5c], BANK[$4]
-Func_10d5c:
-	push af
-	ld a, d
-	sla a
-	sla a
-	sla a
-	sla a
-	add $08
-	ld d, a
-	ld a, e
-	sla a
-	sla a
-	sla a
-	sla a
-	add $10
-	ld e, a
-	pop af
-	ret
-; 0x10d77
-SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
-ClearOWObjectWrapper:
-	call ClearOWObject
-	ret
-; 0x10da7
-
-
 SECTION "Bank 4@4d17", ROMX[$4d17], BANK[$4]
 
 Func_10d17:
@@ -1719,9 +1692,25 @@ GetOWObjectSpriteAnimWrapper:
 GetOWObjectSpriteAnimFlags::
 	call _GetOWObjectSpriteAnimFlags
 	ret
-; 0x10d5c
 
-SECTION "Bank 4@4d77", ROMX[$4d77], BANK[$4]
+Func_10d5c:
+	push af
+	ld a, d
+	sla a
+	sla a
+	sla a
+	sla a
+	add $08
+	ld d, a
+	ld a, e
+	sla a
+	sla a
+	sla a
+	sla a
+	add $10
+	ld e, a
+	pop af
+	ret
 
 ; a = OW_* constant
 LoadOWObjectInMap::
@@ -1757,7 +1746,10 @@ LoadOWObjectInMap::
 	ret
 ; 0x10da3
 
-SECTION "Bank 4@4da7", ROMX[$4da7], BANK[$4]
+SECTION "Bank 4@4da3", ROMX[$4da3], BANK[$4]
+ClearOWObjectWrapper:
+	call ClearOWObject
+	ret
 
 Func_10da7::
 	push af

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -49,7 +49,7 @@ Func_2c0d1:
 	farcall GetEventValue
 	jr z, .asm_2c0ef
 	ld a, OW_ISHIHARA
-	ld de, $102 ; xy coordinate
+	lb de, 1, 2
 	farcall Func_10db8
 	ld b, NORTH
 	farcall SetOWObjectDirection
@@ -624,7 +624,7 @@ Func_2cda2:
 	farcall GetEventValue
 	jr z, .asm_2cdf6
 	ld bc, TILEMAP_013
-	ld de, $506 ; OW coordinates
+	lb de, 5, 6
 	farcall Func_12c0ce
 	jr .asm_2ce0f
 .asm_2cdc6
@@ -1157,7 +1157,7 @@ Func_2dd15:
 	farcall GetEventValue
 	jr z, .asm_2dd2f
 	ld bc, TILEMAP_01A
-	ld de, $500 ; OW coordinates
+	lb de, 5, 0
 	farcall Func_12c0ce
 .asm_2dd2f
 	scf
@@ -1370,7 +1370,7 @@ Func_2e1d9:
 	farcall GetEventValue
 	jr z, .asm_2e1f3
 	ld bc, TILEMAP_01E
-	ld de, $50b ; OW coordinates
+	lb de, 5, 11
 	farcall Func_12c0ce
 .asm_2e1f3
 	scf
@@ -1686,16 +1686,16 @@ Func_2e95c:
 	farcall GetEventValue
 	jr z, .asm_2e994
 	ld bc, TILEMAP_022
-	ld de, $401 ; OW coordinates
+	lb de, 4, 1
 	farcall Func_12c0ce
 	ld bc, TILEMAP_023
-	ld de, $901 ; OW coordinates
+	lb de, 9, 1
 	farcall Func_12c0ce
 	ld bc, TILEMAP_024
-	ld de, $406 ; OW coordinates
+	lb de, 4, 6
 	farcall Func_12c0ce
 	ld bc, TILEMAP_025
-	ld de, $50c ; OW coordinates
+	lb de, 5, 12
 	farcall Func_12c0ce
 .asm_2e994
 	scf
@@ -1989,13 +1989,13 @@ Func_2f0a5:
 	jr .asm_2f0f5
 .asm_2f0c3
 	ld bc, TILEMAP_02A
-	ld de, $204 ; OW coordinates
+	lb de, 2, 4
 	farcall Func_12c0ce
 	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2f0e1
 	ld bc, TILEMAP_029
-	ld de, $50c ; OW coordinates
+	lb de, 5, 12
 	farcall Func_12c0ce
 	jr .asm_2f0f5
 .asm_2f0e1
@@ -2293,10 +2293,10 @@ Func_2f86e:
 	jr .asm_2f8c6
 .asm_2f891
 	ld bc, TILEMAP_02E
-	ld de, $50b ; OW coordinates
+	lb de, 5, 11
 	farcall Func_12c0ce
 	ld bc, TILEMAP_02F
-	ld de, $507 ; OW coordinates
+	lb de, 5, 7
 	farcall Func_12c0ce
 	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
@@ -2400,13 +2400,13 @@ Func_2fe54:
 	cp $00
 	jr nz, .asm_2fe6c
 	ld a, OW_GR_BLIMP
-	ld de, $1080 ; OW coordinates
+	lb de, 16, 128
 	ld b, EAST
 	farcall LoadOWObject
 	jr .asm_2fe77
 .asm_2fe6c
 	ld a, OW_GR_BLIMP
-	ld de, $9010 ; OW coordinates
+	lb de, 144, 16
 	ld b, WEST
 	farcall LoadOWObject
 .asm_2fe77

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -3,7 +3,7 @@ SECTION "Bank b@4000", ROMX[$4000], BANK[$b]
 Data_2c000:
 	db MAP_ISHIHARAS_HOUSE
 	dba Data_2c09b
-	db $23
+	db MUSIC_ISHIHARA
 
 SECTION "Bank b@409b", ROMX[$409b], BANK[$b]
 
@@ -165,7 +165,7 @@ SECTION "Bank b@4479", ROMX[$4479], BANK[$b]
 Data_2c479:
 	db MAP_LIGHTNING_CLUB_1
 	dba Data_2c4c5
-	db $0c
+	db MUSIC_CLUB_1
 
 
 SECTION "Bank b@44c5", ROMX[$44c5], BANK[$b]
@@ -281,7 +281,7 @@ SECTION "Bank b@4936", ROMX[$4936], BANK[$b]
 Data_2c936:
 	db MAP_PSYCHIC_CLUB_ENTRANCE
 	dba Data_2c990
-	db $09
+	db MUSIC_OVERWORLD
 
 
 SECTION "Bank b@4990", ROMX[$4990], BANK[$b]
@@ -507,7 +507,7 @@ PsychicClubEntranceShouldRonaldAppear:
 Data_2cafa:
 	db MAP_PSYCHIC_CLUB_LOBBY
 	dba Data_2cb92
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@4b92", ROMX[$4b92], BANK[$b]
 
@@ -593,7 +593,7 @@ SECTION "Bank b@4d23", ROMX[$4d23], BANK[$b]
 Data_2cd23:
 	db MAP_PSYCHIC_CLUB
 	dba Data_2cd6f
-	db $0d
+	db MUSIC_CLUB_2
 
 SECTION "Bank b@4d6f", ROMX[$4d6f], BANK[$b]
 
@@ -667,7 +667,7 @@ SECTION "Bank b@530a", ROMX[$530a], BANK[$b]
 Data_2d30a:
 	db MAP_ROCK_CLUB_ENTRANCE
 	dba Data_2d346
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@5346", ROMX[$5346], BANK[$b]
 
@@ -752,7 +752,7 @@ Func_2d3b5:
 Data_2d3c4:
 	db MAP_ROCK_CLUB_LOBBY
 	dba Data_2d45c
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@545c", ROMX[$545c], BANK[$b]
 
@@ -841,7 +841,7 @@ SECTION "Bank b@55f8", ROMX[$55f8], BANK[$b]
 Data_2d5f8:
 	db MAP_ROCK_CLUB
 	dba Data_2d640
-	db $0d
+	db MUSIC_CLUB_2
 
 SECTION "Bank b@5640", ROMX[$5640], BANK[$b]
 
@@ -926,7 +926,7 @@ SECTION "Bank b@5930", ROMX[$5930], BANK[$b]
 Data_2d930:
 	db MAP_FIGHTING_CLUB_ENTRANCE
 	dba Data_2d96c
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@596c", ROMX[$596c], BANK[$b]
 
@@ -1051,7 +1051,7 @@ Func_2d9f4:
 Data_2da26:
 	db MAP_FIGHTING_CLUB_LOBBY
 	dba Data_d2abe
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@5abe", ROMX[$5abe], BANK[$b]
 
@@ -1108,7 +1108,7 @@ SECTION "Bank b@5c9f", ROMX[$5c9f], BANK[$b]
 Data_2dc9f:
 	db MAP_FIGHTING_CLUB
 	dba Data_2dceb
-	db $0e
+	db MUSIC_CLUB_3
 
 SECTION "Bank b@5ceb", ROMX[$5ceb], BANK[$b]
 
@@ -1195,7 +1195,7 @@ SECTION "Bank b@606d", ROMX[$606d], BANK[$b]
 Data_2e06d:
 	db MAP_GRASS_CLUB_ENTRANCE
 	dba Data_2e0a9
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@60a9", ROMX[$60a9], BANK[$b]
 
@@ -1321,7 +1321,7 @@ Func_2e131:
 Data_2e163:
 	db MAP_GRASS_CLUB
 	dba Data_2e1af
-	db $0c
+	db MUSIC_CLUB_1
 
 SECTION "Bank b@61af", ROMX[$61af], BANK[$b]
 
@@ -1390,7 +1390,7 @@ SECTION "Bank b@64b7", ROMX[$64b7], BANK[$b]
 Data_2e4b7:
 	db MAP_SCIENCE_CLUB_ENTRANCE
 	dba Data_2e4ff
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@64ff", ROMX[$64ff], BANK[$b]
 
@@ -1545,7 +1545,7 @@ Func_2e62a:
 Data_2e63f:
 	db MAP_SCIENCE_CLUB_LOBBY
 	dba Data_2e6e1
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@66e1", ROMX[$66e1], BANK[$b]
 
@@ -1637,7 +1637,7 @@ SECTION "Bank b@68e6", ROMX[$68e6], BANK[$b]
 Data_2e8e6:
 	db MAP_SCIENCE_CLUB
 	dba Data_2e932
-	db $0e
+	db MUSIC_CLUB_3
 
 SECTION "Bank b@6932", ROMX[$6932], BANK[$b]
 
@@ -1715,7 +1715,7 @@ SECTION "Bank b@6cc8", ROMX[$6cc8], BANK[$b]
 Data_2ecc8:
 	db MAP_WATER_CLUB_ENTRANCE
 	dba Data_2ed04
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@6d04", ROMX[$6d04], BANK[$b]
 
@@ -1838,7 +1838,7 @@ Func_2eda8:
 Data_2edc5:
 	db MAP_WATER_CLUB_LOBBY
 	dba Data_2ee5d
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@6e5d", ROMX[$6e5d], BANK[$b]
 
@@ -1930,7 +1930,7 @@ SECTION "Bank b@7012", ROMX[$7012], BANK[$b]
 Data_2f012:
 	db MAP_WATER_CLUB
 	dba Data_2f072
-	db $0c
+	db MUSIC_CLUB_1
 
 SECTION "Bank b@7072", ROMX[$7072], BANK[$b]
 
@@ -2041,7 +2041,7 @@ SECTION "Bank b@74ff", ROMX[$74ff], BANK[$b]
 Data_2f4ff:
 	db MAP_FIRE_CLUB_ENTRANCE
 	dba Data_2f53b
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@753b", ROMX[$753b], BANK[$b]
 
@@ -2169,7 +2169,7 @@ Func_2f5ca:
 Data_2f5fc:
 	db MAP_FIRE_CLUB_LOBBY
 	dba Data_2f68a
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@768a", ROMX[$768a], BANK[$b]
 
@@ -2255,7 +2255,7 @@ SECTION "Bank b@77ca", ROMX[$77ca], BANK[$b]
 Data_2f7ca:
 	db MAP_FIRE_CLUB
 	dba Data_2f83b
-	db $0e
+	db MUSIC_CLUB_3
 
 SECTION "Bank b@783b", ROMX[$783b], BANK[$b]
 
@@ -2321,7 +2321,7 @@ SECTION "Bank b@7cd5", ROMX[$7cd5], BANK[$b]
 Data_2fcd5:
 	db MAP_POKEMON_DOME_ENTRANCE
 	dba Data_2fd66
-	db $09
+	db MUSIC_OVERWORLD
 
 SECTION "Bank b@7d66", ROMX[$7d66], BANK[$b]
 
@@ -2372,7 +2372,7 @@ SECTION "Bank b@7e45", ROMX[$7e45], BANK[$b]
 Data_2fe45:
 	db MAP_OVERHEAD_ISLANDS
 	dba Data_2fe4a
-	db $1e
+	db MUSIC_GRBLIMP
 
 Data_2fe4a:
 	dbw $02, Func_2fe54

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -318,7 +318,7 @@ Func_2c9c8:
 	scf
 	ret
 .asm_2c9cf
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -532,7 +532,7 @@ Func_2cbba:
 	scf
 	ret
 .asm_2cbc6
-	ld a, $10
+	ld a, MUSIC_IMAKUNI
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -685,7 +685,7 @@ Func_2d366:
 	scf
 	ret
 .asm_2d36d
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -777,7 +777,7 @@ Func_2d489:
 	scf
 	ret
 .asm_2d495
-	ld a, $10
+	ld a, MUSIC_IMAKUNI
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -944,7 +944,7 @@ Func_2d98f:
 	scf
 	ret
 .asm_2d996
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -1211,7 +1211,7 @@ Func_2e0cc:
 	scf
 	ret
 .asm_2e0d3
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -1407,7 +1407,7 @@ Func_2e528:
 	scf
 	ret
 .asm_2e52f
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -1563,7 +1563,7 @@ Func_2e709:
 	scf
 	ret
 .asm_2e715
-	ld a, $10
+	ld a, MUSIC_IMAKUNI
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -1725,7 +1725,7 @@ Func_2ed27:
 	scf
 	ret
 .asm_2ed2e
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -1851,7 +1851,7 @@ Func_2ee85:
 	scf
 	ret
 .asm_2ee91
-	ld a, $10
+	ld a, MUSIC_IMAKUNI
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -2050,7 +2050,7 @@ Func_2f55e:
 	scf
 	ret
 .asm_2f565
-	ld a, $0f
+	ld a, MUSIC_RONALD
 	farcall PlayAfterCurrentSong
 	scf
 	ccf
@@ -2181,7 +2181,7 @@ Func_2f6b2:
 	scf
 	ret
 .asm_2f6be
-	ld a, $10
+	ld a, MUSIC_IMAKUNI
 	farcall PlayAfterCurrentSong
 	scf
 	ccf

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -43,9 +43,11 @@ Func_2c0c8:
 Func_2c0d1:
 	xor a
 	call Func_33f2
-	ld h, h
-	ld de, $3e00
-	push af
+	; Event Script @ 0x2c0d5
+	db $64
+	db $11
+	db $00
+	ld a, EVENT_F5
 	farcall GetEventValue
 	jr z, .asm_2c0ef
 	ld a, OW_ISHIHARA
@@ -210,7 +212,6 @@ Func_2c501:
 	ccf
 	ret
 
-; TODO: this funtion's disasm is a little weird. may not be correct
 Func_2c50a:
 	ld a, EVENT_MET_GR4_LIGHTNING_CLUB
 	farcall GetEventValue
@@ -234,30 +235,39 @@ Func_2c50a:
 	ld [$d594], a
 	xor a
 	call Func_33f2
-	ld [hli], a
-	ld [hli], a
-	dec b
-	add hl, bc
-	ld [bc], a
-	ld [hli], a
-	inc h
-	ld [$209], sp
-	ld [hli], a
-	ld sp, DecompressData.get_sequence_len
-	ld [bc], a
-	nop
+	; Event Script @ 0x2c53d
+	db $22
+	db $22
+	db $05
+	db $09
+	db $02
+	db $22
+	db $24
+	db $08
+	db $09
+	db $02
+	db $22
+	db $31
+	db $07
+	db $09
+	db $02
+	db $00
 	jr .asm_2c55e
 .asm_2c54f
 	xor a
 	call Func_33f2
-	ld [hli], a
-	ld [hli], a
-	dec b
-	ld b, $02
-	ld [hli], a
-	inc h
-	ld [$208], sp
-	nop
+	; Event Script @ 0x2c553
+	db $22
+	db $22
+	db $05
+	db $06
+	db $02
+	db $22
+	db $24
+	db $08
+	db $08
+	db $02
+	db $00
 .asm_2c55e
 	scf
 	ret
@@ -451,10 +461,13 @@ Func_2caa0:
 	ld [$d610], a
 	xor a
 	call Func_33f2
-	ld bc, $cb05
-	dec bc
-	ld [bc], a
-	nop
+	; Event Script @ 0x2cab4
+	db $01
+	db $05
+	db $cb
+	db $0b
+	db $02
+	db $00
 	ret
 
 Func_2cabb:
@@ -631,9 +644,82 @@ Func_2cd99:
 ; 0x2cda2
 
 Func_2cda2:
-; TODO: function hangs when running tcg2disasm.py
-
-SECTION "Bank b@4e11", ROMX[$4e11], BANK[$b]
+	ld a, EVENT_MET_GR4_PSYCHIC_CLUB
+	farcall GetEventValue
+	jr z, .asm_2cdc6
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
+	farcall GetEventValue
+	jr nz, .asm_2cdf6
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
+	farcall GetEventValue
+	jr z, .asm_2cdf6
+	ld bc, TILEMAP_013
+	ld de, $506 ; OW coordinates
+	farcall Func_12c0ce
+	jr .asm_2ce0f
+.asm_2cdc6
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0b
+	ld [wd592], a
+	ld hl, $4e39
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+	xor a
+	call Func_33f2
+	; Event Script @ 0x2cddf
+	db $22
+	db $26
+	db $07
+	db $06
+	db $02
+	db $22
+	db $27
+	db $05
+	db $06
+	db $02
+	db $22
+	db $28
+	db $06
+	db $06
+	db $02
+	db $22
+	db $29
+	db $08
+	db $0a
+	db $02
+	db $00
+	jr .asm_2ce0f
+.asm_2cdf6
+	xor a
+	call Func_33f2
+	; Event Script @ 0x2cdfa
+	db $22
+	db $26
+	db $06
+	db $03
+	db $02
+	db $22
+	db $27
+	db $05
+	db $06
+	db $02
+	db $22
+	db $28
+	db $06
+	db $0a
+	db $02
+	db $22
+	db $29
+	db $08
+	db $0a
+	db $02
+	db $00
+.asm_2ce0f
+	scf
+	ret
 
 Func_2ce11:
 	ld hl, $4d5a
@@ -892,17 +978,23 @@ Func_2d673:
 	ld [$d594], a
 	xor a
 	call Func_33f2
-	ld [hli], a
-	ld a, [bc]
-	dec b
-	ld bc, $2202
-	dec bc
-	ld [$201], sp
-	ld [hli], a
-	inc c
-	ld b, $01
-	ld [bc], a
-	nop
+	; Event Script @ 0x2d694
+	db $22
+	db $0a
+	db $05
+	db $01
+	db $02
+	db $22
+	db $0b
+	db $08
+	db $01
+	db $02
+	db $22
+	db $0c
+	db $06
+	db $01
+	db $02
+	db $00
 .asm_2d6a4
 	scf
 	ret
@@ -1759,9 +1851,10 @@ Func_2ed37:
 Func_2ed3e:
 	xor a
 	call Func_33f2
-	ld h, h
-	ld [de], a
-	nop
+	; Event Script @ 0x2ed42
+	db $64
+	db $12
+	db $00
 	call Func_2eda8
 	jr c, .asm_2ed73
 	or a
@@ -1972,19 +2065,23 @@ Func_2f0a5:
 	jr nz, .asm_2f0c3
 	xor a
 	call Func_33f2
-	dec d
-	xor h
-	inc b
-	ld b, $02
-	dec d
-	xor l
-	inc bc
-	ld b, $01
-	dec d
-	xor [hl]
-	dec b
-	ld b, $03
-	nop
+	; Event Script @ 0x2f0b1
+	db $15
+	db $ac
+	db $04
+	db $06
+	db $02
+	db $15
+	db $ad
+	db $03
+	db $06
+	db $01
+	db $15
+	db $ae
+	db $05
+	db $06
+	db $03
+	db $00
 	jr .asm_2f0f5
 .asm_2f0c3
 	ld bc, TILEMAP_02A
@@ -2000,20 +2097,23 @@ Func_2f0a5:
 .asm_2f0e1
 	xor a
 	call Func_33f2
-	ld [hli], a
-	add hl, de
-	add hl, bc
-	dec b
-	ld [bc], a
-	ld [hli], a
-	inc e
-	ld [$205], sp
-	ld [hli], a
-	dec e
-	ld a, [bc]
-	dec b
-	ld [bc], a
-	nop
+	; Event Script @ 0x2f0e5
+	db $22
+	db $19
+	db $09
+	db $05
+	db $02
+	db $22
+	db $1c
+	db $08
+	db $05
+	db $02
+	db $22
+	db $1d
+	db $0a
+	db $05
+	db $02
+	db $00
 .asm_2f0f5
 	scf
 	ret
@@ -2085,9 +2185,10 @@ Func_2f56e:
 Func_2f575:
 	xor a
 	call Func_33f2
-	ld h, h
-	ld [de], a
-	nop
+	; Event Script @ 0x2f579
+	db $64
+	db $12
+	db $00
 	call Func_2f5ca
 	jr c, .asm_2f5a6
 	cp $01
@@ -2292,10 +2393,71 @@ Func_2f865:
 	ret
 
 Func_2f86e:
-; TODO: this function doesn't want to disasm
-
-
-SECTION "Bank b@78c8", ROMX[$78c8], BANK[$b]
+	ld a, EVENT_GOT_CHARMANDER_COIN
+	farcall GetEventValue
+	jr nz, .asm_2f891
+	xor a
+	call Func_33f2
+	; Event Script @ 0x2f87a
+	db $22
+	db $1e
+	db $07
+	db $0a
+	db $02
+	db $22
+	db $1f
+	db $06
+	db $0a
+	db $02
+	db $22
+	db $20
+	db $05
+	db $0a
+	db $02
+	db $22
+	db $21
+	db $08
+	db $0a
+	db $02
+	db $00
+	jr .asm_2f8c6
+.asm_2f891
+	ld bc, TILEMAP_02E
+	ld de, $50b ; OW coordinates
+	farcall Func_12c0ce
+	ld bc, TILEMAP_02F
+	ld de, $507 ; OW coordinates
+	farcall Func_12c0ce
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
+	farcall GetEventValue
+	jr z, .asm_2f8c6
+	xor a
+	call Func_33f2
+	; Event Script @ 0x2f8b1
+	db $22
+	db $1e
+	db $07
+	db $0a
+	db $02
+	db $22
+	db $1f
+	db $06
+	db $0a
+	db $02
+	db $22
+	db $20
+	db $05
+	db $0a
+	db $02
+	db $22
+	db $21
+	db $08
+	db $0a
+	db $02
+	db $00
+.asm_2f8c6
+	scf
+	ret
 
 Func_2f8c8:
 	ld hl, $7801

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -68,14 +68,14 @@ Func_2c0f1:
 Func_2c101:
 	xor a
 	push af
-	ld a, $f5
+	ld a, EVENT_F5
 	farcall GetEventValue
 	jr z, .asm_2c10f
 	pop af
 	or $01
 	push af
 .asm_2c10f
-	ld a, $f4
+	ld a, EVENT_ISHIHARA_CARD_TRADE_STATE
 	farcall GetEventValue
 	jr z, .asm_2c11b
 	pop af
@@ -88,7 +88,7 @@ Func_2c101:
 	ld c, a
 	ld a, $00
 	farcall SetVarValue
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall MaxOutEventValue
 .asm_2c12c
 	scf
@@ -96,7 +96,7 @@ Func_2c101:
 	ret
 
 Func_2c12f:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, $00
 	farcall ZeroOutVarValue
@@ -105,7 +105,7 @@ Func_2c12f:
 	ret
 
 Func_2c13e:
-	ld a, $f5
+	ld a, EVENT_F5
 	farcall ZeroOutEventValue
 	ld a, $00
 	farcall GetVarValue
@@ -115,7 +115,7 @@ Func_2c13e:
 	pop af
 	bit 1, a
 	call nz, Func_2c16b
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, $00
 	farcall ZeroOutVarValue
@@ -123,12 +123,12 @@ Func_2c13e:
 	ret
 
 Func_2c164:
-	ld a, $f5
+	ld a, EVENT_F5
 	farcall MaxOutEventValue
 	ret
 
 Func_2c16b:
-	ld a, $f4
+	ld a, EVENT_ISHIHARA_CARD_TRADE_STATE
 	farcall MaxOutEventValue
 	ret
 ; 0x2c172
@@ -141,12 +141,12 @@ Func_2c1b8:
 	cp $05
 	jr c, .asm_2c1d8
 	jr nz, .asm_2c1ce
-	ld a, $f4
+	ld a, EVENT_ISHIHARA_CARD_TRADE_STATE
 	farcall GetEventValue
 	jr nz, .asm_2c1d8
 	jr .asm_2c1d6
 .asm_2c1ce
-	ld a, $f5
+	ld a, EVENT_F5
 	farcall GetEventValue
 	jr nz, .asm_2c1d8
 .asm_2c1d6
@@ -185,7 +185,7 @@ Func_2c4db:
 	ld [wd58e], a
 	jr .asm_2c4f7
 .asm_2c4ea
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2c4f7
 	ld a, $09
@@ -212,7 +212,7 @@ Func_2c50a:
 	ld a, EVENT_MET_GR4_LIGHTNING_CLUB
 	farcall GetEventValue
 	jr z, .asm_2c524
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2c54f
 	ld a, EVENT_GOT_PIKACHU_COIN
@@ -303,7 +303,7 @@ Func_2c9ac:
 	ret
 
 Func_2c9b8:
-	ld a, $0f
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2c9c5
 	ld a, $14
@@ -372,12 +372,12 @@ Func_2ca1c:
 	ret
 
 Func_2ca22:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2ca3c
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -566,12 +566,12 @@ Func_2cbef:
 	ret
 
 Func_2cbf5:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2cc0f
 	ld a, $05
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -669,7 +669,7 @@ Data_2d346:
 	db $ff
 
 Func_2d356:
-	ld a, $98
+	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d363
 	ld a, $14
@@ -713,12 +713,12 @@ Func_2d37d:
 	ret
 
 Func_2d399:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d3b3
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -756,7 +756,7 @@ Data_2d45c:
 	db $ff
 
 Func_2d472:
-	ld a, $98
+	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d486
 	ld a, $14
@@ -811,12 +811,12 @@ Func_2d4be:
 	ret
 
 Func_2d4c4:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d4de
 	ld a, $05
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -844,7 +844,7 @@ Data_2d640:
 	db $ff
 
 Func_2d653:
-	ld a, $98
+	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d660
 	ld a, $14
@@ -867,7 +867,7 @@ Func_2d66a:
 	ret
 
 Func_2d673:
-	ld a, $98
+	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d6a4
 	ld a, $0a
@@ -928,7 +928,7 @@ Data_2d96c:
 	db $ff
 
 Func_2d97f:
-	ld a, $0c
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2d98c
 	ld a, $14
@@ -988,12 +988,12 @@ Func_2d9d2:
 
 SECTION "Bank b@59d8", ROMX[$59d8], BANK[$b]
 Func_2d9d8:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d9f2
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1050,7 +1050,7 @@ Data_d2abe:
 	dbw $01, Func_2dace
 	db $ff
 Func_2dace:
-	ld a, $0c
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2dadb
 	ld a, $14
@@ -1109,7 +1109,7 @@ Data_2dceb:
 	db $ff
 
 Func_2dcfe:
-	ld a, $0c
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2dd0b
 	ld a, $14
@@ -1125,10 +1125,10 @@ Func_2dd0e:
 	ret
 
 Func_2dd15:
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2dd2f
-	ld a, $0c
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr z, .asm_2dd2f
 	ld bc, $1a
@@ -1195,7 +1195,7 @@ Data_2e0a9:
 	db $ff
 
 Func_2e0bc:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e0c9
 	ld a, $14
@@ -1257,12 +1257,12 @@ Func_2e10f:
 SECTION "Bank b@6115", ROMX[$6115], BANK[$b]
 
 Func_2e115:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e12f
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1321,7 +1321,7 @@ Data_2e1af:
 	db $ff
 
 Func_2e1c2:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e1cf
 	ld a, $14
@@ -1337,10 +1337,10 @@ Func_2e1d2:
 	ret
 
 Func_2e1d9:
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2e1f3
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr z, .asm_2e1f3
 	ld bc, $1e
@@ -1391,7 +1391,7 @@ Data_2e4ff:
 	db $ff
 
 Func_2e518:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e525
 	ld a, $14
@@ -1463,12 +1463,12 @@ Func_2e57c:
 	ret
 
 Func_2e582:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e59c
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1514,10 +1514,10 @@ Func_2e59e:
 SECTION "Bank b@662a", ROMX[$662a], BANK[$b]
 
 Func_2e62a:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr z, .asm_2e63c
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2e63c
 	scf
@@ -1544,7 +1544,7 @@ Data_2e6e1:
 	db $ff
 
 Func_2e6f7:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e706
 	ld a, $14
@@ -1601,12 +1601,12 @@ Func_2e73e:
 
 SECTION "Bank b@6752", ROMX[$6752], BANK[$b]
 Func_2e752:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e76c
 	ld a, $05
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1632,7 +1632,7 @@ Data_2e932:
 	db $ff
 
 Func_2e945:
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e952
 	ld a, $14
@@ -1647,10 +1647,10 @@ Func_2e955:
 	ret
 
 Func_2e95c:
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2e994
-	ld a, $0d
+	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr z, .asm_2e994
 	ld bc, $22
@@ -1708,7 +1708,7 @@ Data_2ed04:
 	db $ff
 
 Func_2ed17:
-	ld a, $07
+	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2ed24
 	ld a, $14
@@ -1751,7 +1751,7 @@ Func_2ed3e:
 	ld hl, $40a4
 	jr .asm_2ed61
 .asm_2ed58
-	ld a, $ee
+	ld a, EVENT_EE
 	farcall ZeroOutEventValue
 	ld hl, $451d
 .asm_2ed61
@@ -1768,25 +1768,25 @@ Func_2ed3e:
 	ret
 
 Func_2ed75:
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr z, .asm_2ed8a
 	ld a, [wd585]
 	cp $00
 	jr nz, .asm_2ed8a
-	ld a, $33
+	ld a, EVENT_TALKED_TO_SARA
 	farcall ZeroOutEventValue
 .asm_2ed8a
 	scf
 	ret
 
 Func_2ed8c:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2eda6
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1799,7 +1799,7 @@ Func_2eda8:
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2edbc
-	ld a, $ee
+	ld a, EVENT_EE
 	farcall GetEventValue
 	jr nz, .asm_2edc0
 	scf
@@ -1832,7 +1832,7 @@ Data_2ee5d:
 	db $ff
 
 Func_2ee73:
-	ld a, $07
+	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2ee82
 	ld a, $14
@@ -1889,12 +1889,12 @@ Func_2eeba:
 
 SECTION "Bank b@6ece", ROMX[$6ece], BANK[$b]
 Func_2eece:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2eee8
 	ld a, $05
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -1921,7 +1921,7 @@ Data_2f072:
 	db $ff
 
 Func_2f085:
-	ld a, $07
+	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2f092
 	ld a, $14
@@ -1944,7 +1944,7 @@ Func_2f09c:
 	ret
 
 Func_2f0a5:
-	ld a, $07
+	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2f0c3
 	xor a
@@ -1967,7 +1967,7 @@ Func_2f0a5:
 	ld bc, $2a
 	ld de, $204
 	farcall Func_12c0ce
-	ld a, $ed
+	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2f0e1
 	ld bc, $29
@@ -2034,7 +2034,7 @@ Data_2f53b:
 	db $ff
 
 Func_2f54e:
-	ld a, $0e
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f55b
 	ld a, $14
@@ -2098,12 +2098,12 @@ Func_2f5a8:
 	ret
 
 Func_2f5ae:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2f5c8
 	ld a, $03
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -2162,7 +2162,7 @@ Data_2f68a:
 	db $ff
 
 Func_2f6a0:
-	ld a, $0e
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f6af
 	ld a, $14
@@ -2215,12 +2215,12 @@ Func_2f6e7:
 	ret
 
 Func_2f6ed:
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2f707
 	ld a, $05
 	farcall Func_10da3
-	ld a, $03
+	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
 	ld [wCurMusic], a
@@ -2246,7 +2246,7 @@ Data_2f83b:
 	db $ff
 
 Func_2f84e:
-	ld a, $0e
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f85b
 	ld a, $14
@@ -2308,7 +2308,7 @@ Data_2fd66:
 	db $ff
 
 Func_2fd73:
-	ld a, $0b
+	ld a, EVENT_GOT_GR_COIN
 	farcall GetEventValue
 	jr nz, .asm_2fd80
 	ld a, $14

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -188,8 +188,8 @@ Func_2c4db:
 	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2c4f7
-	ld a, $09
-	ld [wd58a], a
+	ld a, MAP_LIGHTNING_CLUB_2
+	ld [wCurMap], a
 .asm_2c4f7
 	scf
 	ccf

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -368,7 +368,7 @@ Func_2ca22:
 	farcall GetEventValue
 	jr z, .asm_2ca3c
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -562,7 +562,7 @@ Func_2cbf5:
 	farcall GetEventValue
 	jr z, .asm_2cc0f
 	ld a, OW_IMAKUNI_BLACK
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -748,7 +748,7 @@ Func_2d399:
 	farcall GetEventValue
 	jr z, .asm_2d3b3
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -848,7 +848,7 @@ Func_2d4c4:
 	farcall GetEventValue
 	jr z, .asm_2d4de
 	ld a, OW_IMAKUNI_BLACK
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1019,7 +1019,7 @@ Func_2d9d8:
 	farcall GetEventValue
 	jr z, .asm_2d9f2
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1274,7 +1274,7 @@ Func_2e115:
 	farcall GetEventValue
 	jr z, .asm_2e12f
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1483,7 +1483,7 @@ Func_2e582:
 	farcall GetEventValue
 	jr z, .asm_2e59c
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1625,7 +1625,7 @@ Func_2e752:
 	farcall GetEventValue
 	jr z, .asm_2e76c
 	ld a, OW_IMAKUNI_BLACK
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1807,7 +1807,7 @@ Func_2ed8c:
 	farcall GetEventValue
 	jr z, .asm_2eda6
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1922,7 +1922,7 @@ Func_2eece:
 	farcall GetEventValue
 	jr z, .asm_2eee8
 	ld a, OW_IMAKUNI_BLACK
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -2108,7 +2108,7 @@ Func_2f5ae:
 	farcall GetEventValue
 	jr z, .asm_2f5c8
 	ld a, OW_RONALD
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -2228,7 +2228,7 @@ Func_2f6ed:
 	farcall GetEventValue
 	jr z, .asm_2f707
 	ld a, OW_IMAKUNI_BLACK
-	farcall _ClearOWObject
+	farcall ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -1184,24 +1184,6 @@ Func_2dd42:
 	ret
 ; 0x2dd4d
 
-SECTION "Bank b@5d9c", ROMX[$5d9c], BANK[$b]
-
-Func_2dd9c:
-	dec b
-	sub b
-	ld [$2], sp
-	ret
-; 0x2dda2
-
-SECTION "Bank b@5ef2", ROMX[$5ef2], BANK[$b]
-
-Func_2def2:
-	dec b
-	xor c
-	ld [$2], sp
-	ret
-; 0x2def8
-
 SECTION "Bank b@606d", ROMX[$606d], BANK[$b]
 
 Data_2e06d:

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -1,20 +1,20 @@
 SECTION "Bank b@4000", ROMX[$4000], BANK[$b]
 Data_2c000:
-    db MAP_ISHIHARAS_HOUSE
-    dba Data_2c09b
-    db $23
+	db MAP_ISHIHARAS_HOUSE
+	dba Data_2c09b
+	db $23
 
 SECTION "Bank b@409b", ROMX[$409b], BANK[$b]
 Data_2c09b:
-    dbw $06, Func_2c0c1
-    dbw $08, Func_2c0f1
-    dbw $07, Func_2c0c8
-    dbw $02, Func_2c0d1
-    dbw $0c, Func_2c101
-    dbw $0d, Func_2c12f
-    dbw $0b, Func_2c13e
-    dbw $01, Func_2c0b4
-    db $ff
+	dbw $06, Func_2c0c1
+	dbw $08, Func_2c0f1
+	dbw $07, Func_2c0c8
+	dbw $02, Func_2c0d1
+	dbw $0c, Func_2c101
+	dbw $0d, Func_2c12f
+	dbw $0b, Func_2c13e
+	dbw $01, Func_2c0b4
+	db $ff
 
 Func_2c0b4:
 	call Func_2c1b8
@@ -160,22 +160,22 @@ Func_2c1b8:
 
 SECTION "Bank b@4479", ROMX[$4479], BANK[$b]
 Data_2c479:
-    db MAP_LIGHTNING_CLUB_1
-    dba Data_2c4c5
-    db $0c
+	db MAP_LIGHTNING_CLUB_1
+	dba Data_2c4c5
+	db $0c
 
 
 SECTION "Bank b@44c5", ROMX[$44c5], BANK[$b]
 
 Data_2c4c5:
-    dbw $06, Func_2c4fa
-    dbw $08, Func_2c560
-    dbw $09, Func_2c568
-    dbw $07, Func_2c501
-    dbw $01, Func_2c4db
-    dbw $02, Func_2c50a
-    dbw $01, Func_2c4db
-    db $ff
+	dbw $06, Func_2c4fa
+	dbw $08, Func_2c560
+	dbw $09, Func_2c568
+	dbw $07, Func_2c501
+	dbw $01, Func_2c4db
+	dbw $02, Func_2c50a
+	dbw $01, Func_2c4db
+	db $ff
 
 Func_2c4db:
 	ld a, EVENT_GOT_PIKACHU_COIN
@@ -199,7 +199,7 @@ Func_2c4fa:
 	ld hl, $447e
 	call Func_324d
 	ret
-    
+
 Func_2c501:
 	ld hl, $4491
 	call Func_3205
@@ -276,23 +276,23 @@ Func_2c568:
 SECTION "Bank b@4936", ROMX[$4936], BANK[$b]
 
 Data_2c936:
-    db MAP_PSYCHIC_CLUB_ENTRANCE
-    dba Data_2c990
-    db $09
+	db MAP_PSYCHIC_CLUB_ENTRANCE
+	dba Data_2c990
+	db $09
 
 
 SECTION "Bank b@4990", ROMX[$4990], BANK[$b]
 Data_2c990:
-    dbw $00, Func_2c9ac
-    dbw $06, Func_2c9d8
-    dbw $08, Func_2ca14
-    dbw $09, Func_2ca1c
-    dbw $07, Func_2c9df
-    dbw $02, Func_2c9e8
-    dbw $0b, Func_2ca22
-    dbw $01, Func_2c9b8
-    dbw $10, Func_2c9c8
-    db $ff
+	dbw $00, Func_2c9ac
+	dbw $06, Func_2c9d8
+	dbw $08, Func_2ca14
+	dbw $09, Func_2ca1c
+	dbw $07, Func_2c9df
+	dbw $02, Func_2c9e8
+	dbw $0b, Func_2ca22
+	dbw $01, Func_2c9b8
+	dbw $10, Func_2c9c8
+	db $ff
 
 Func_2c9ac:
 	call Func_3332
@@ -312,6 +312,7 @@ Func_2c9b8:
 	scf
 	ccf
 	ret
+
 Func_2c9c8:
 	call PsychicClubEntranceShouldRonaldAppear
 	jr nc, .asm_2c9cf
@@ -328,6 +329,7 @@ Func_2c9d8:
 	ld hl, $493b
 	call Func_324d
 	ret
+
 Func_2c9df:
 	ld hl, $4984
 	call Func_3205
@@ -366,6 +368,7 @@ Func_2ca14:
 	call Func_328c
 	scf
 	ret
+	
 Func_2ca1c:
 	farcall Func_341c4
 	scf
@@ -462,7 +465,7 @@ Func_2cabb:
 	ret
 
 ; sets and complements carry flag if Ronald should appear.
-; return a = which meeting script to use 
+; return a = which meeting script to use
 PsychicClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
@@ -498,21 +501,21 @@ PsychicClubEntranceShouldRonaldAppear:
 	ret
 
 Data_2cafa:
-    db MAP_PSYCHIC_CLUB_LOBBY
-    dba Data_2cb92
-    db $09
+	db MAP_PSYCHIC_CLUB_LOBBY
+	dba Data_2cb92
+	db $09
 
 SECTION "Bank b@4b92", ROMX[$4b92], BANK[$b]
 
 Data_2cb92:
-    dbw $06, Func_2cbcf
-    dbw $08, Func_2cbdf
-    dbw $07, Func_2cbd6
-    dbw $09, Func_2cbef
-    dbw $0b, Func_2cbf5
-    dbw $01, Func_2cba8
-    dbw $10, Func_2cbba
-    db $ff
+	dbw $06, Func_2cbcf
+	dbw $08, Func_2cbdf
+	dbw $07, Func_2cbd6
+	dbw $09, Func_2cbef
+	dbw $0b, Func_2cbf5
+	dbw $01, Func_2cba8
+	dbw $10, Func_2cbba
+	db $ff
 
 Func_2cba8:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
@@ -590,13 +593,13 @@ Data_2cd23:
 SECTION "Bank b@4d6f", ROMX[$4d6f], BANK[$b]
 
 Data_2cd6f:
-    dbw $06, Func_2cd92
-    dbw $08, Func_2ce11
-    dbw $09, Func_2ce19
-    dbw $07, Func_2cd99
-    dbw $02, Func_2cda2
-    dbw $01, Func_2cd82
-    db $ff
+	dbw $06, Func_2cd92
+	dbw $08, Func_2ce11
+	dbw $09, Func_2ce19
+	dbw $07, Func_2cd99
+	dbw $02, Func_2cda2
+	dbw $01, Func_2cd82
+	db $ff
 
 Func_2cd82:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
@@ -939,7 +942,7 @@ Func_2d97f:
 	scf
 	ccf
 	ret
-	
+
 Func_2d98f:
 	call Func_2d9f4
 	jr nc, .asm_2d996
@@ -1061,7 +1064,7 @@ Func_2dace:
 	scf
 	ccf
 	ret
-	
+
 Func_2dade:
 	ld hl, $5a2b
 	call Func_324d
@@ -1642,6 +1645,7 @@ Func_2e945:
 	scf
 	ccf
 	ret
+
 Func_2e955:
 	ld hl, $68eb
 	call Func_324d
@@ -1718,7 +1722,6 @@ Func_2ed17:
 	scf
 	ccf
 	ret
-; 0x2ed27
 
 Func_2ed27:
 	call Func_2eda8

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -368,7 +368,7 @@ Func_2ca14:
 	call Func_328c
 	scf
 	ret
-	
+
 Func_2ca1c:
 	farcall Func_341c4
 	scf
@@ -484,7 +484,7 @@ PsychicClubEntranceShouldRonaldAppear:
 	ccf
 	ret
 .third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $02
 	jr nz, .asm_2cada
 	ld a, $01
@@ -492,7 +492,7 @@ PsychicClubEntranceShouldRonaldAppear:
 	ccf
 	ret
 .fourth_meeting ; after 4 GR pieces. Ronald tells you he got the stolen cards back
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $04
 	jr nz, .asm_2cada
 	ld a, $02
@@ -1024,7 +1024,7 @@ Func_2d9f4:
 	ccf
 	ret
 .asm_2da0c
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $02
 	jr nz, .asm_2da06
 	ld a, $01
@@ -1032,7 +1032,7 @@ Func_2d9f4:
 	ccf
 	ret
 .asm_2da19
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $04
 	jr nz, .asm_2da06
 	ld a, $02
@@ -1292,7 +1292,7 @@ Func_2e131:
 	ccf
 	ret
 .asm_2e149
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $02
 	jr nz, .asm_2e143
 	ld a, $01
@@ -1300,7 +1300,7 @@ Func_2e131:
 	ccf
 	ret
 .asm_2e156
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $04
 	jr nz, .asm_2e143
 	ld a, $02
@@ -1498,7 +1498,7 @@ Func_2e59e:
 	ccf
 	ret
 .asm_2e5b6
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $02
 	jr nz, .asm_2e5b0
 	ld a, $01
@@ -1506,7 +1506,7 @@ Func_2e59e:
 	ccf
 	ret
 .asm_2e5c3
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $04
 	jr nz, .asm_2e5b0
 	ld a, $02
@@ -2130,7 +2130,7 @@ Func_2f5ca:
 	ccf
 	ret
 .asm_2f5e2
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $02
 	jr nz, .asm_2f5dc
 	ld a, $01
@@ -2138,7 +2138,7 @@ Func_2f5ca:
 	ccf
 	ret
 .asm_2f5ef
-	farcall CountGRCoinPieces
+	farcall CountGRCoinPiecesObtained
 	cp $04
 	jr nz, .asm_2f5dc
 	ld a, $02

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -46,11 +46,11 @@ Func_2c0d1:
 	push af
 	farcall GetEventValue
 	jr z, .asm_2c0ef
-	ld a, $04
-	ld de, $102
+	ld a, OW_ISHIHARA
+	ld de, $102 ; xy coordinate
 	farcall Func_10db8
-	ld b, $00
-	farcall Func_10dcf
+	ld b, NORTH
+	farcall SetOWObjectDirectionWrapper
 .asm_2c0ef
 	scf
 	ret
@@ -398,8 +398,8 @@ Func_2ca46:
 	bit 6, a
 	jr z, .asm_2ca9f
 	ld a, [wPlayerOWObject]
-	ld b, $00
-	farcall Func_10dcf
+	ld b, NORTH
+	farcall SetOWObjectDirectionWrapper
 	farcall Func_10da7
 	ld a, $02
 	cp e
@@ -2355,21 +2355,19 @@ Data_2fe4a:
 	db $ff
 
 Func_2fe54:
-; this function is related to the overhead island map, but
-; apparently loads OW Objects for Mint and Ronald? Seems wrong
 	farcall InitOWObjects
 	ld a, [wd584]
 	cp $00
 	jr nz, .asm_2fe6c
-	ld a, $d1
-	ld de, $1080
-	ld b, $01
+	ld a, OW_GR_BLIMP
+	ld de, $1080 ; OW coordinates
+	ld b, EAST
 	farcall LoadOWObject
 	jr .asm_2fe77
 .asm_2fe6c
-	ld a, $d1
-	ld de, $9010
-	ld b, $03
+	ld a, OW_GR_BLIMP
+	ld de, $9010 ; OW coordinates
+	ld b, WEST
 	farcall LoadOWObject
 .asm_2fe77
 	ld a, $0a

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -140,7 +140,7 @@ SECTION "Bank b@41b8", ROMX[$41b8], BANK[$b]
 Func_2c1b8:
 	ld a, VAR_02
 	farcall GetVarValue
-	cp $05
+	cp 5
 	jr c, .asm_2c1d8
 	jr nz, .asm_2c1ce
 	ld a, EVENT_ISHIHARA_CARD_TRADE_STATE
@@ -329,7 +329,7 @@ Func_2c9df:
 Func_2c9e8:
 	call PsychicClubEntranceShouldRonaldAppear
 	jr c, .asm_2ca12
-	cp $01
+	cp 1
 	jr z, .asm_2c9f8
 	jr nc, .asm_2c9fd
 	ld hl, $4037
@@ -456,11 +456,11 @@ Func_2cabb:
 PsychicClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .second_meeting
-	cp $03
+	cp 3
 	jr c, .third_meeting
-	cp $04
+	cp 4
 	jr c, .fourth_meeting
 .asm_2cada
 	scf
@@ -472,17 +472,17 @@ PsychicClubEntranceShouldRonaldAppear:
 	ret
 .third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
 	farcall CountGRCoinPiecesObtained
-	cp $02
+	cp 2
 	jr nz, .asm_2cada
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
 .fourth_meeting ; after 4 GR pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPiecesObtained
-	cp $04
+	cp 4
 	jr nz, .asm_2cada
-	ld a, $02
+	ld a, 2
 	scf
 	ccf
 	ret
@@ -519,7 +519,7 @@ Func_2cba8:
 Func_2cbba:
 	ld a, VAR_25
 	farcall GetVarValue
-	cp $03
+	cp 3
 	jr z, .asm_2cbc6
 	scf
 	ret
@@ -760,7 +760,7 @@ Func_2d399:
 Func_2d3b5:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2d3c1
 	scf
 	ret
@@ -803,7 +803,7 @@ Func_2d472:
 Func_2d489:
 	ld a, VAR_25
 	farcall GetVarValue
-	cp $04
+	cp 4
 	jr z, .asm_2d495
 	scf
 	ret
@@ -982,7 +982,7 @@ Func_2d99f:
 Func_2d9a6:
 	call Func_2d9f4
 	jr c, .asm_2d9d0
-	cp $01
+	cp 1
 	jr z, .asm_2d9b6
 	jr nc, .asm_2d9bb
 	ld hl, $4037
@@ -1029,11 +1029,11 @@ Func_2d9d8:
 Func_2d9f4:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2da08
-	cp $03
+	cp 3
 	jr c, .asm_2da0c
-	cp $04
+	cp 4
 	jr c, .asm_2da19
 .asm_2da06
 	scf
@@ -1045,17 +1045,17 @@ Func_2d9f4:
 	ret
 .asm_2da0c
 	farcall CountGRCoinPiecesObtained
-	cp $02
+	cp 2
 	jr nz, .asm_2da06
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
 .asm_2da19
 	farcall CountGRCoinPiecesObtained
-	cp $04
+	cp 4
 	jr nz, .asm_2da06
-	ld a, $02
+	ld a, 2
 	scf
 	ccf
 	ret
@@ -1233,7 +1233,7 @@ Func_2e0dc:
 Func_2e0e3:
 	call Func_2e131
 	jr c, .asm_2e10d
-	cp $01
+	cp 1
 	jr z, .asm_2e0f3
 	jr nc, .asm_2e0f8
 	ld hl, $4037
@@ -1281,11 +1281,11 @@ Func_2e115:
 Func_2e131:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2e145
-	cp $03
+	cp 3
 	jr c, .asm_2e149
-	cp $04
+	cp 4
 	jr c, .asm_2e156
 .asm_2e143
 	scf
@@ -1297,17 +1297,17 @@ Func_2e131:
 	ret
 .asm_2e149
 	farcall CountGRCoinPiecesObtained
-	cp $02
+	cp 2
 	jr nz, .asm_2e143
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
 .asm_2e156
 	farcall CountGRCoinPiecesObtained
-	cp $04
+	cp 4
 	jr nz, .asm_2e143
-	ld a, $02
+	ld a, 2
 	scf
 	ccf
 	ret
@@ -1437,7 +1437,7 @@ Func_2e53f:
 Func_2e548:
 	call Func_2e59e
 	jr c, .asm_2e572
-	cp $01
+	cp 1
 	jr z, .asm_2e558
 	jr nc, .asm_2e55d
 	ld hl, $4037
@@ -1488,11 +1488,11 @@ Func_2e582:
 Func_2e59e:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2e5b2
-	cp $03
+	cp 3
 	jr c, .asm_2e5b6
-	cp $04
+	cp 4
 	jr c, .asm_2e5c3
 .asm_2e5b0
 	scf
@@ -1504,17 +1504,17 @@ Func_2e59e:
 	ret
 .asm_2e5b6
 	farcall CountGRCoinPiecesObtained
-	cp $02
+	cp 2
 	jr nz, .asm_2e5b0
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
 .asm_2e5c3
 	farcall CountGRCoinPiecesObtained
-	cp $04
+	cp 4
 	jr nz, .asm_2e5b0
-	ld a, $02
+	ld a, 2
 	scf
 	ccf
 	ret
@@ -1568,7 +1568,7 @@ Func_2e6f7:
 Func_2e709:
 	ld a, VAR_25
 	farcall GetVarValue
-	cp $07
+	cp 7
 	jr z, .asm_2e715
 	scf
 	ret
@@ -1785,7 +1785,7 @@ Func_2ed75:
 	farcall GetEventValue
 	jr z, .asm_2ed8a
 	ld a, [wd585]
-	cp $00
+	cp 0
 	jr nz, .asm_2ed8a
 	ld a, EVENT_TALKED_TO_SARA
 	farcall ZeroOutEventValue
@@ -1810,7 +1810,7 @@ Func_2ed8c:
 Func_2eda8:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2edbc
 	ld a, EVENT_EE
 	farcall GetEventValue
@@ -1823,7 +1823,7 @@ Func_2eda8:
 	ccf
 	ret
 .asm_2edc0
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
@@ -1860,7 +1860,7 @@ Func_2ee73:
 Func_2ee85:
 	ld a, VAR_25
 	farcall GetVarValue
-	cp $08
+	cp 8
 	jr z, .asm_2ee91
 	scf
 	ret
@@ -2061,7 +2061,7 @@ Func_2f575:
 	db $64, $12, $00
 	call Func_2f5ca
 	jr c, .asm_2f5a6
-	cp $01
+	cp 1
 	jr z, .asm_2f58c
 	jr nc, .asm_2f591
 	ld hl, $4037
@@ -2106,11 +2106,11 @@ Func_2f5ae:
 Func_2f5ca:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
-	cp $02
+	cp 2
 	jr c, .asm_2f5de
-	cp $03
+	cp 3
 	jr c, .asm_2f5e2
-	cp $04
+	cp 4
 	jr c, .asm_2f5ef
 .asm_2f5dc
 	scf
@@ -2122,17 +2122,17 @@ Func_2f5ca:
 	ret
 .asm_2f5e2
 	farcall CountGRCoinPiecesObtained
-	cp $02
+	cp 2
 	jr nz, .asm_2f5dc
-	ld a, $01
+	ld a, 1
 	scf
 	ccf
 	ret
 .asm_2f5ef
 	farcall CountGRCoinPiecesObtained
-	cp $04
+	cp 4
 	jr nz, .asm_2f5dc
-	ld a, $02
+	ld a, 2
 	scf
 	ccf
 	ret
@@ -2169,7 +2169,7 @@ Func_2f6a0:
 Func_2f6b2:
 	ld a, VAR_25
 	farcall GetVarValue
-	cp $09
+	cp 9
 	jr z, .asm_2f6be
 	scf
 	ret
@@ -2379,7 +2379,7 @@ Data_2fe4a:
 Func_2fe54:
 	farcall InitOWObjects
 	ld a, [wd584]
-	cp $00
+	cp 0
 	jr nz, .asm_2fe6c
 	ld a, OW_GR_BLIMP
 	lb de, 16, 128

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -375,8 +375,8 @@ Func_2ca22:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2ca3c
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -569,8 +569,8 @@ Func_2cbf5:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2cc0f
-	ld a, $05
-	farcall Func_10da3
+	ld a, OW_IMAKUNI_BLACK
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -716,8 +716,8 @@ Func_2d399:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d3b3
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -814,8 +814,8 @@ Func_2d4c4:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d4de
-	ld a, $05
-	farcall Func_10da3
+	ld a, OW_IMAKUNI_BLACK
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -991,8 +991,8 @@ Func_2d9d8:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2d9f2
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -1255,13 +1255,12 @@ Func_2e10f:
 ; 0x2e115
 
 SECTION "Bank b@6115", ROMX[$6115], BANK[$b]
-
 Func_2e115:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e12f
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -1466,8 +1465,8 @@ Func_2e582:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e59c
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -1604,8 +1603,8 @@ Func_2e752:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2e76c
-	ld a, $05
-	farcall Func_10da3
+	ld a, OW_IMAKUNI_BLACK
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -1784,8 +1783,8 @@ Func_2ed8c:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2eda6
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -1892,8 +1891,8 @@ Func_2eece:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2eee8
-	ld a, $05
-	farcall Func_10da3
+	ld a, OW_IMAKUNI_BLACK
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -2101,8 +2100,8 @@ Func_2f5ae:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2f5c8
-	ld a, $03
-	farcall Func_10da3
+	ld a, OW_RONALD
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -2218,8 +2217,8 @@ Func_2f6ed:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
 	jr z, .asm_2f707
-	ld a, $05
-	farcall Func_10da3
+	ld a, OW_IMAKUNI_BLACK
+	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wd58e]
@@ -2356,6 +2355,8 @@ Data_2fe4a:
 	db $ff
 
 Func_2fe54:
+; this function is related to the overhead island map, but
+; apparently loads OW Objects for Mint and Ronald? Seems wrong
 	farcall InitOWObjects
 	ld a, [wd584]
 	cp $00

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -50,7 +50,7 @@ Func_2c0d1:
 	ld de, $102 ; xy coordinate
 	farcall Func_10db8
 	ld b, NORTH
-	farcall SetOWObjectDirectionWrapper
+	farcall SetOWObjectDirection
 .asm_2c0ef
 	scf
 	ret
@@ -379,7 +379,7 @@ Func_2ca22:
 	farcall GetEventValue
 	jr z, .asm_2ca3c
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -402,7 +402,7 @@ Func_2ca46:
 	jr z, .asm_2ca9f
 	ld a, [wPlayerOWObject]
 	ld b, NORTH
-	farcall SetOWObjectDirectionWrapper
+	farcall SetOWObjectDirection
 	farcall Func_10da7
 	ld a, $02
 	cp e
@@ -575,7 +575,7 @@ Func_2cbf5:
 	farcall GetEventValue
 	jr z, .asm_2cc0f
 	ld a, OW_IMAKUNI_BLACK
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -722,7 +722,7 @@ Func_2d399:
 	farcall GetEventValue
 	jr z, .asm_2d3b3
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -820,7 +820,7 @@ Func_2d4c4:
 	farcall GetEventValue
 	jr z, .asm_2d4de
 	ld a, OW_IMAKUNI_BLACK
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -997,7 +997,7 @@ Func_2d9d8:
 	farcall GetEventValue
 	jr z, .asm_2d9f2
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1265,7 +1265,7 @@ Func_2e115:
 	farcall GetEventValue
 	jr z, .asm_2e12f
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1471,7 +1471,7 @@ Func_2e582:
 	farcall GetEventValue
 	jr z, .asm_2e59c
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1609,7 +1609,7 @@ Func_2e752:
 	farcall GetEventValue
 	jr z, .asm_2e76c
 	ld a, OW_IMAKUNI_BLACK
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1789,7 +1789,7 @@ Func_2ed8c:
 	farcall GetEventValue
 	jr z, .asm_2eda6
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -1897,7 +1897,7 @@ Func_2eece:
 	farcall GetEventValue
 	jr z, .asm_2eee8
 	ld a, OW_IMAKUNI_BLACK
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -2103,7 +2103,7 @@ Func_2f5ae:
 	farcall GetEventValue
 	jr z, .asm_2f5c8
 	ld a, OW_RONALD
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]
@@ -2220,7 +2220,7 @@ Func_2f6ed:
 	farcall GetEventValue
 	jr z, .asm_2f707
 	ld a, OW_IMAKUNI_BLACK
-	farcall ClearOWObjectWrapper
+	farcall _ClearOWObject
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
 	ld a, [wNextMusic]

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -1131,8 +1131,8 @@ Func_2dd15:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr z, .asm_2dd2f
-	ld bc, $1a
-	ld de, $500
+	ld bc, TILEMAP_01A
+	ld de, $500 ; OW coordinates
 	farcall Func_12c0ce
 .asm_2dd2f
 	scf
@@ -1342,8 +1342,8 @@ Func_2e1d9:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr z, .asm_2e1f3
-	ld bc, $1e
-	ld de, $50b
+	ld bc, TILEMAP_01E
+	ld de, $50b ; OW coordinates
 	farcall Func_12c0ce
 .asm_2e1f3
 	scf
@@ -1652,17 +1652,17 @@ Func_2e95c:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr z, .asm_2e994
-	ld bc, $22
-	ld de, $401
+	ld bc, TILEMAP_022
+	ld de, $401 ; OW coordinates
 	farcall Func_12c0ce
-	ld bc, $23
-	ld de, $901
+	ld bc, TILEMAP_023
+	ld de, $901 ; OW coordinates
 	farcall Func_12c0ce
-	ld bc, $24
-	ld de, SetBGP
+	ld bc, TILEMAP_024
+	ld de, $406 ; OW coordinates
 	farcall Func_12c0ce
-	ld bc, $25
-	ld de, $50c
+	ld bc, TILEMAP_025
+	ld de, $50c ; OW coordinates
 	farcall Func_12c0ce
 .asm_2e994
 	scf
@@ -1963,14 +1963,14 @@ Func_2f0a5:
 	nop
 	jr .asm_2f0f5
 .asm_2f0c3
-	ld bc, $2a
-	ld de, $204
+	ld bc, TILEMAP_02A
+	ld de, $204 ; OW coordinates
 	farcall Func_12c0ce
 	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
 	farcall GetEventValue
 	jr nz, .asm_2f0e1
-	ld bc, $29
-	ld de, $50c
+	ld bc, TILEMAP_029
+	ld de, $50c ; OW coordinates
 	farcall Func_12c0ce
 	jr .asm_2f0f5
 .asm_2f0e1

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -19,8 +19,8 @@ Data_2c09b:
 Func_2c0b4:
 	call Func_2c1b8
 	jr nc, .asm_2c0be
-	ld a, $09
-	ld [wd58e], a
+	ld a, MUSIC_OVERWORLD
+	ld [wNextMusic], a
 .asm_2c0be
 	scf
 	ccf
@@ -181,8 +181,8 @@ Func_2c4db:
 	ld a, EVENT_GOT_PIKACHU_COIN
 	farcall GetEventValue
 	jr nz, .asm_2c4ea
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2c4f7
 .asm_2c4ea
 	ld a, EVENT_SET_UNTIL_MAP_RELOAD_1
@@ -306,8 +306,8 @@ Func_2c9b8:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2c9c5
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2c9c5
 	scf
 	ccf
@@ -379,7 +379,7 @@ Func_2ca22:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2ca3c
 	scf
@@ -516,8 +516,8 @@ Func_2cba8:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2cbb7
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2cbb7
 .asm_2cbb7
 	scf
@@ -573,7 +573,7 @@ Func_2cbf5:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2cc0f
 	scf
@@ -600,8 +600,8 @@ Func_2cd82:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2cd8f
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2cd8f
 	scf
 	ccf
@@ -672,8 +672,8 @@ Func_2d356:
 	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d363
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2d363
 	scf
 	ccf
@@ -720,7 +720,7 @@ Func_2d399:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2d3b3
 	scf
@@ -759,11 +759,11 @@ Func_2d472:
 	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d486
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2d486
-	ld a, $10
-	ld [wd58e], a
+	ld a, MUSIC_IMAKUNI
+	ld [wNextMusic], a
 .asm_2d486
 	scf
 	ccf
@@ -818,7 +818,7 @@ Func_2d4c4:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2d4de
 	scf
@@ -847,8 +847,8 @@ Func_2d653:
 	ld a, EVENT_MET_GR1_ROCK_CLUB
 	farcall GetEventValue
 	jr nz, .asm_2d660
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2d660
 	scf
 	ccf
@@ -931,8 +931,8 @@ Func_2d97f:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2d98c
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2d98c
 	scf
 	ccf
@@ -995,7 +995,7 @@ Func_2d9d8:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2d9f2
 	scf
@@ -1053,8 +1053,8 @@ Func_2dace:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2dadb
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2dadb
 	scf
 	ccf
@@ -1112,8 +1112,8 @@ Func_2dcfe:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2dd0b
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2dd0b
 	scf
 	ccf
@@ -1198,8 +1198,8 @@ Func_2e0bc:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e0c9
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2e0c9
 	scf
 	ccf
@@ -1263,7 +1263,7 @@ Func_2e115:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2e12f
 	scf
@@ -1323,8 +1323,8 @@ Func_2e1c2:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e1cf
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2e1cf
 	scf
 	ccf
@@ -1393,8 +1393,8 @@ Func_2e518:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e525
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2e525
 	scf
 	ccf
@@ -1469,7 +1469,7 @@ Func_2e582:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2e59c
 	scf
@@ -1546,8 +1546,8 @@ Func_2e6f7:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e706
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2e706
 .asm_2e706
 	scf
@@ -1607,7 +1607,7 @@ Func_2e752:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2e76c
 	scf
@@ -1634,8 +1634,8 @@ Func_2e945:
 	ld a, EVENT_GOT_GR_COIN_PIECE_TOP_RIGHT
 	farcall GetEventValue
 	jr nz, .asm_2e952
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2e952
 	scf
 	ccf
@@ -1710,8 +1710,8 @@ Func_2ed17:
 	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2ed24
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2ed24
 	scf
 	ccf
@@ -1787,7 +1787,7 @@ Func_2ed8c:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2eda6
 	scf
@@ -1834,8 +1834,8 @@ Func_2ee73:
 	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2ee82
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2ee82
 .asm_2ee82
 	scf
@@ -1895,7 +1895,7 @@ Func_2eece:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2eee8
 	scf
@@ -1923,8 +1923,8 @@ Func_2f085:
 	ld a, EVENT_GOT_STARMIE_COIN
 	farcall GetEventValue
 	jr nz, .asm_2f092
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2f092
 	scf
 	ccf
@@ -2036,8 +2036,8 @@ Func_2f54e:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f55b
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2f55b
 	scf
 	ccf
@@ -2104,7 +2104,7 @@ Func_2f5ae:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2f5c8
 	scf
@@ -2164,8 +2164,8 @@ Func_2f6a0:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f6af
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 	jr .asm_2f6af
 .asm_2f6af
 	scf
@@ -2221,7 +2221,7 @@ Func_2f6ed:
 	farcall ClearOWObjectWrapper
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, [wd58e]
+	ld a, [wNextMusic]
 	ld [wCurMusic], a
 .asm_2f707
 	scf
@@ -2248,8 +2248,8 @@ Func_2f84e:
 	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_LEFT
 	farcall GetEventValue
 	jr nz, .asm_2f85b
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2f85b
 	scf
 	ccf
@@ -2310,8 +2310,8 @@ Func_2fd73:
 	ld a, EVENT_GOT_GR_COIN
 	farcall GetEventValue
 	jr nz, .asm_2fd80
-	ld a, $14
-	ld [wd58e], a
+	ld a, MUSIC_HERECOMESGR
+	ld [wNextMusic], a
 .asm_2fd80
 	scf
 	ccf

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -44,9 +44,7 @@ Func_2c0d1:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2c0d5
-	db $64
-	db $11
-	db $00
+	db $64, $11, $00
 	ld a, EVENT_F5
 	farcall GetEventValue
 	jr z, .asm_2c0ef
@@ -236,37 +234,14 @@ Func_2c50a:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2c53d
-	db $22
-	db $22
-	db $05
-	db $09
-	db $02
-	db $22
-	db $24
-	db $08
-	db $09
-	db $02
-	db $22
-	db $31
-	db $07
-	db $09
-	db $02
-	db $00
+	db $22, $22, $05, $09, $02, $22, $24, $08, $09, $02
+	db $22, $31, $07, $09, $02, $00
 	jr .asm_2c55e
 .asm_2c54f
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2c553
-	db $22
-	db $22
-	db $05
-	db $06
-	db $02
-	db $22
-	db $24
-	db $08
-	db $08
-	db $02
+	db $22, $22, $05, $06, $02, $22, $24, $08, $08, $02
 	db $00
 .asm_2c55e
 	scf
@@ -462,12 +437,7 @@ Func_2caa0:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2cab4
-	db $01
-	db $05
-	db $cb
-	db $0b
-	db $02
-	db $00
+	db $01, $05, $cb, $0b, $02, $00
 	ret
 
 Func_2cabb:
@@ -670,52 +640,16 @@ Func_2cda2:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2cddf
-	db $22
-	db $26
-	db $07
-	db $06
-	db $02
-	db $22
-	db $27
-	db $05
-	db $06
-	db $02
-	db $22
-	db $28
-	db $06
-	db $06
-	db $02
-	db $22
-	db $29
-	db $08
-	db $0a
-	db $02
+	db $22, $26, $07, $06, $02, $22, $27, $05, $06, $02
+	db $22, $28, $06, $06, $02, $22, $29, $08, $0a, $02
 	db $00
 	jr .asm_2ce0f
 .asm_2cdf6
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2cdfa
-	db $22
-	db $26
-	db $06
-	db $03
-	db $02
-	db $22
-	db $27
-	db $05
-	db $06
-	db $02
-	db $22
-	db $28
-	db $06
-	db $0a
-	db $02
-	db $22
-	db $29
-	db $08
-	db $0a
-	db $02
+	db $22, $26, $06, $03, $02, $22, $27, $05, $06, $02
+	db $22, $28, $06, $0a, $02, $22, $29, $08, $0a, $02
 	db $00
 .asm_2ce0f
 	scf
@@ -979,22 +913,8 @@ Func_2d673:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2d694
-	db $22
-	db $0a
-	db $05
-	db $01
-	db $02
-	db $22
-	db $0b
-	db $08
-	db $01
-	db $02
-	db $22
-	db $0c
-	db $06
-	db $01
-	db $02
-	db $00
+	db $22, $0a, $05, $01, $02, $22, $0b, $08, $01, $02
+	db $22, $0c, $06, $01, $02, $00
 .asm_2d6a4
 	scf
 	ret
@@ -1852,9 +1772,7 @@ Func_2ed3e:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2ed42
-	db $64
-	db $12
-	db $00
+	db $64, $12, $00
 	call Func_2eda8
 	jr c, .asm_2ed73
 	or a
@@ -2066,22 +1984,8 @@ Func_2f0a5:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2f0b1
-	db $15
-	db $ac
-	db $04
-	db $06
-	db $02
-	db $15
-	db $ad
-	db $03
-	db $06
-	db $01
-	db $15
-	db $ae
-	db $05
-	db $06
-	db $03
-	db $00
+	db $15, $ac, $04, $06, $02, $15, $ad, $03, $06, $01
+	db $15, $ae, $05, $06, $03, $00
 	jr .asm_2f0f5
 .asm_2f0c3
 	ld bc, TILEMAP_02A
@@ -2098,22 +2002,8 @@ Func_2f0a5:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2f0e5
-	db $22
-	db $19
-	db $09
-	db $05
-	db $02
-	db $22
-	db $1c
-	db $08
-	db $05
-	db $02
-	db $22
-	db $1d
-	db $0a
-	db $05
-	db $02
-	db $00
+	db $22, $19, $09, $05, $02, $22, $1c, $08, $05, $02
+	db $22, $1d, $0a, $05, $02, $00
 .asm_2f0f5
 	scf
 	ret
@@ -2186,9 +2076,7 @@ Func_2f575:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2f579
-	db $64
-	db $12
-	db $00
+	db $64, $12, $00
 	call Func_2f5ca
 	jr c, .asm_2f5a6
 	cp $01
@@ -2399,26 +2287,8 @@ Func_2f86e:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2f87a
-	db $22
-	db $1e
-	db $07
-	db $0a
-	db $02
-	db $22
-	db $1f
-	db $06
-	db $0a
-	db $02
-	db $22
-	db $20
-	db $05
-	db $0a
-	db $02
-	db $22
-	db $21
-	db $08
-	db $0a
-	db $02
+	db $22, $1e, $07, $0a, $02, $22, $1f, $06, $0a, $02
+	db $22, $20, $05, $0a, $02, $22, $21, $08, $0a, $02
 	db $00
 	jr .asm_2f8c6
 .asm_2f891
@@ -2434,26 +2304,8 @@ Func_2f86e:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x2f8b1
-	db $22
-	db $1e
-	db $07
-	db $0a
-	db $02
-	db $22
-	db $1f
-	db $06
-	db $0a
-	db $02
-	db $22
-	db $20
-	db $05
-	db $0a
-	db $02
-	db $22
-	db $21
-	db $08
-	db $0a
-	db $02
+	db $22, $1e, $07, $0a, $02, $22, $1f, $06, $0a, $02
+	db $22, $20, $05, $0a, $02, $22, $21, $08, $0a, $02
 	db $00
 .asm_2f8c6
 	scf

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -478,7 +478,7 @@ PsychicClubEntranceShouldRonaldAppear:
 	scf
 	ccf
 	ret
-.fourth_meeting ; after 4 GR pieces. Ronald tells you he got the stolen cards back
+.fourth_meeting ; after 4 GC pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPiecesObtained
 	cp 4
 	jr nz, .asm_2cada
@@ -711,7 +711,7 @@ Func_2d356:
 	ret
 
 Func_2d366:
-	call Func_2d3b5
+	call RockClubEntranceShouldRonaldAppear
 	jr nc, .asm_2d36d
 	scf
 	ret
@@ -728,7 +728,7 @@ Func_2d376:
 	ret
 
 Func_2d37d:
-	call Func_2d3b5
+	call RockClubEntranceShouldRonaldAppear
 	jr c, .asm_2d397
 	ld a, $0a
 	ld [wd582], a
@@ -757,14 +757,16 @@ Func_2d399:
 	scf
 	ret
 
-Func_2d3b5:
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+RockClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2d3c1
+	jr c, .second_meeting
 	scf
 	ret
-.asm_2d3c1
+.second_meeting ; second meeting - Ronald card pops with you
 	scf
 	ccf
 	ret
@@ -963,7 +965,7 @@ Func_2d97f:
 	ret
 
 Func_2d98f:
-	call Func_2d9f4
+	call FightningClubEntranceShouldRonaldAppear
 	jr nc, .asm_2d996
 	scf
 	ret
@@ -980,7 +982,7 @@ Func_2d99f:
 	ret
 
 Func_2d9a6:
-	call Func_2d9f4
+	call FightningClubEntranceShouldRonaldAppear
 	jr c, .asm_2d9d0
 	cp 1
 	jr z, .asm_2d9b6
@@ -1026,24 +1028,27 @@ Func_2d9d8:
 	scf
 	ret
 
-Func_2d9f4:
+
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+FightningClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2da08
+	jr c, .second_meeting
 	cp 3
-	jr c, .asm_2da0c
+	jr c, .third_meeting
 	cp 4
-	jr c, .asm_2da19
+	jr c, .fourth_meeting
 .asm_2da06
 	scf
 	ret
-.asm_2da08
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
 	ret
-.asm_2da0c
+.third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
 	farcall CountGRCoinPiecesObtained
 	cp 2
 	jr nz, .asm_2da06
@@ -1051,7 +1056,7 @@ Func_2d9f4:
 	scf
 	ccf
 	ret
-.asm_2da19
+.fourth_meeting ; after 4 GC pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPiecesObtained
 	cp 4
 	jr nz, .asm_2da06
@@ -1214,7 +1219,7 @@ Func_2e0bc:
 	ret
 
 Func_2e0cc:
-	call Func_2e131
+	call GrassClubEntranceShouldRonaldAppear
 	jr nc, .asm_2e0d3
 	scf
 	ret
@@ -1231,7 +1236,7 @@ Func_2e0dc:
 	ret
 
 Func_2e0e3:
-	call Func_2e131
+	call GrassClubEntranceShouldRonaldAppear
 	jr c, .asm_2e10d
 	cp 1
 	jr z, .asm_2e0f3
@@ -1278,33 +1283,35 @@ Func_2e115:
 	scf
 	ret
 
-Func_2e131:
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+GrassClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2e145
+	jr c, .second_meeting
 	cp 3
-	jr c, .asm_2e149
+	jr c, .third_meeting
 	cp 4
-	jr c, .asm_2e156
+	jr c, .fourth_meeting
 .asm_2e143
 	scf
 	ret
-.asm_2e145
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
 	ret
-.asm_2e149
-	farcall CountGRCoinPiecesObtained
+.third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
+	farcall CountGRCoinPiecesObtained 
 	cp 2
 	jr nz, .asm_2e143
 	ld a, 1
 	scf
 	ccf
 	ret
-.asm_2e156
-	farcall CountGRCoinPiecesObtained
+.fourth_meeting ; after 4 GC pieces. Ronald tells you he got the stolen cards back
+	farcall CountGRCoinPiecesObtained 
 	cp 4
 	jr nz, .asm_2e143
 	ld a, 2
@@ -1411,7 +1418,7 @@ Func_2e518:
 	ret
 
 Func_2e528:
-	call Func_2e59e
+	call ScienceClubEntranceShouldRonaldAppear
 	jr nc, .asm_2e52f
 	scf
 	ret
@@ -1435,7 +1442,7 @@ Func_2e53f:
 	ret
 
 Func_2e548:
-	call Func_2e59e
+	call ScienceClubEntranceShouldRonaldAppear
 	jr c, .asm_2e572
 	cp 1
 	jr z, .asm_2e558
@@ -1485,24 +1492,26 @@ Func_2e582:
 	scf
 	ret
 
-Func_2e59e:
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+ScienceClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2e5b2
+	jr c, .second_meeting
 	cp 3
-	jr c, .asm_2e5b6
+	jr c, .third_meeting
 	cp 4
-	jr c, .asm_2e5c3
+	jr c, .fourth_meeting
 .asm_2e5b0
 	scf
 	ret
-.asm_2e5b2
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
 	ret
-.asm_2e5b6
+.third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
 	farcall CountGRCoinPiecesObtained
 	cp 2
 	jr nz, .asm_2e5b0
@@ -1510,7 +1519,7 @@ Func_2e59e:
 	scf
 	ccf
 	ret
-.asm_2e5c3
+.fourth_meeting ; after 4 GC pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPiecesObtained
 	cp 4
 	jr nz, .asm_2e5b0
@@ -1734,7 +1743,7 @@ Func_2ed17:
 	ret
 
 Func_2ed27:
-	call Func_2eda8
+	call WaterClubEntranceShouldRonaldAppear
 	jr nc, .asm_2ed2e
 	scf
 	ret
@@ -1755,7 +1764,7 @@ Func_2ed3e:
 	call Func_33f2
 	; Event Script @ 0x2ed42
 	db $64, $12, $00
-	call Func_2eda8
+	call WaterClubEntranceShouldRonaldAppear
 	jr c, .asm_2ed73
 	or a
 	jr nz, .asm_2ed58
@@ -1807,17 +1816,22 @@ Func_2ed8c:
 	scf
 	ret
 
-Func_2eda8:
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+;
+; This club is an anomaly. For other clubs, return "1" triggers the 3rd meeting,
+; but only if you have 2 GC pieces. Here it checks EVENT_EE instead of GC pieces
+WaterClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2edbc
+	jr c, .second_meeting
 	ld a, EVENT_EE
 	farcall GetEventValue
 	jr nz, .asm_2edc0
 	scf
 	ret
-.asm_2edbc
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
@@ -2038,7 +2052,7 @@ Func_2f54e:
 	ret
 
 Func_2f55e:
-	call Func_2f5ca
+	call FireClubEntranceShouldRonaldAppear
 	jr nc, .asm_2f565
 	scf
 	ret
@@ -2059,7 +2073,7 @@ Func_2f575:
 	call Func_33f2
 	; Event Script @ 0x2f579
 	db $64, $12, $00
-	call Func_2f5ca
+	call FireClubEntranceShouldRonaldAppear
 	jr c, .asm_2f5a6
 	cp 1
 	jr z, .asm_2f58c
@@ -2103,24 +2117,26 @@ Func_2f5ae:
 	scf
 	ret
 
-Func_2f5ca:
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use
+FireClubEntranceShouldRonaldAppear:
 	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp 2
-	jr c, .asm_2f5de
+	jr c, .second_meeting
 	cp 3
-	jr c, .asm_2f5e2
+	jr c, .third_meeting
 	cp 4
-	jr c, .asm_2f5ef
+	jr c, .fourth_meeting
 .asm_2f5dc
 	scf
 	ret
-.asm_2f5de
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
 	ret
-.asm_2f5e2
+.third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
 	farcall CountGRCoinPiecesObtained
 	cp 2
 	jr nz, .asm_2f5dc
@@ -2128,7 +2144,7 @@ Func_2f5ca:
 	scf
 	ccf
 	ret
-.asm_2f5ef
+.fourth_meeting ; after 4 GC pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPiecesObtained
 	cp 4
 	jr nz, .asm_2f5dc

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -454,7 +454,7 @@ Func_2cabb:
 ; sets and complements carry flag if Ronald should appear.
 ; return a = which meeting script to use
 PsychicClubEntranceShouldRonaldAppear:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .second_meeting
@@ -758,7 +758,7 @@ Func_2d399:
 	ret
 
 Func_2d3b5:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2d3c1
@@ -1027,7 +1027,7 @@ Func_2d9d8:
 	ret
 
 Func_2d9f4:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2da08
@@ -1279,7 +1279,7 @@ Func_2e115:
 	ret
 
 Func_2e131:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e145
@@ -1486,7 +1486,7 @@ Func_2e582:
 	ret
 
 Func_2e59e:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e5b2
@@ -1808,7 +1808,7 @@ Func_2ed8c:
 	ret
 
 Func_2eda8:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2edbc
@@ -2104,7 +2104,7 @@ Func_2f5ae:
 	ret
 
 Func_2f5ca:
-	ld a, VAR_TIMES_RONALD_MET
+	ld a, VAR_TIMES_MET_RONALD
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2f5de

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -86,7 +86,7 @@ Func_2c101:
 	or a
 	jr z, .asm_2c12c
 	ld c, a
-	ld a, $00
+	ld a, VAR_00
 	farcall SetVarValue
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall MaxOutEventValue
@@ -98,7 +98,7 @@ Func_2c101:
 Func_2c12f:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, $00
+	ld a, VAR_00
 	farcall ZeroOutVarValue
 	scf
 	ccf
@@ -107,7 +107,7 @@ Func_2c12f:
 Func_2c13e:
 	ld a, EVENT_F5
 	farcall ZeroOutEventValue
-	ld a, $00
+	ld a, VAR_00
 	farcall GetVarValue
 	bit 0, a
 	push af
@@ -117,7 +117,7 @@ Func_2c13e:
 	call nz, Func_2c16b
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall ZeroOutEventValue
-	ld a, $00
+	ld a, VAR_00
 	farcall ZeroOutVarValue
 	scf
 	ret
@@ -136,7 +136,7 @@ Func_2c16b:
 SECTION "Bank b@41b8", ROMX[$41b8], BANK[$b]
 
 Func_2c1b8:
-	ld a, $02
+	ld a, VAR_02
 	farcall GetVarValue
 	cp $05
 	jr c, .asm_2c1d8
@@ -462,7 +462,7 @@ Func_2cabb:
 	ret
 
 Func_2cac8:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2cadc
@@ -525,7 +525,7 @@ Func_2cba8:
 	ret
 
 Func_2cbba:
-	ld a, $25
+	ld a, VAR_25
 	farcall GetVarValue
 	cp $03
 	jr z, .asm_2cbc6
@@ -727,7 +727,7 @@ Func_2d399:
 	ret
 
 Func_2d3b5:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2d3c1
@@ -770,7 +770,7 @@ Func_2d472:
 	ret
 
 Func_2d489:
-	ld a, $25
+	ld a, VAR_25
 	farcall GetVarValue
 	cp $04
 	jr z, .asm_2d495
@@ -1002,7 +1002,7 @@ Func_2d9d8:
 	ret
 
 Func_2d9f4:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2da08
@@ -1271,7 +1271,7 @@ Func_2e115:
 	ret
 
 Func_2e131:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e145
@@ -1477,7 +1477,7 @@ Func_2e582:
 	ret
 
 Func_2e59e:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e5b2
@@ -1556,7 +1556,7 @@ Func_2e6f7:
 	ret
 
 Func_2e709:
-	ld a, $25
+	ld a, VAR_25
 	farcall GetVarValue
 	cp $07
 	jr z, .asm_2e715
@@ -1795,7 +1795,7 @@ Func_2ed8c:
 	ret
 
 Func_2eda8:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2edbc
@@ -1844,7 +1844,7 @@ Func_2ee73:
 	ret
 
 Func_2ee85:
-	ld a, $25
+	ld a, VAR_25
 	farcall GetVarValue
 	cp $08
 	jr z, .asm_2ee91
@@ -2112,7 +2112,7 @@ Func_2f5ae:
 	ret
 
 Func_2f5ca:
-	ld a, $04
+	ld a, VAR_04
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2f5de
@@ -2174,7 +2174,7 @@ Func_2f6a0:
 	ret
 
 Func_2f6b2:
-	ld a, $25
+	ld a, VAR_25
 	farcall GetVarValue
 	cp $09
 	jr z, .asm_2f6be

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -2007,15 +2007,12 @@ Func_2f0f7:
 	ret
 
 Func_2f107:
-	ld hl, Func_2f112
+	ld hl, $7112
 	ld a, [$d60e]
 	call Func_344c
 	scf
 	ret
-
-Func_2f112:
-; TODO: this function doesn't want to disasm cleanly, but is
-; required in Func_2f107
+; 0x2f112
 
 SECTION "Bank b@74ff", ROMX[$74ff], BANK[$b]
 

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -313,7 +313,7 @@ Func_2c9b8:
 	ccf
 	ret
 Func_2c9c8:
-	call Func_2cac8
+	call PsychicClubEntranceShouldRonaldAppear
 	jr nc, .asm_2c9cf
 	scf
 	ret
@@ -336,7 +336,7 @@ Func_2c9df:
 	ret
 
 Func_2c9e8:
-	call Func_2cac8
+	call PsychicClubEntranceShouldRonaldAppear
 	jr c, .asm_2ca12
 	cp $01
 	jr z, .asm_2c9f8
@@ -461,24 +461,26 @@ Func_2cabb:
 	ccf
 	ret
 
-Func_2cac8:
-	ld a, VAR_04
+; sets and complements carry flag if Ronald should appear.
+; return a = which meeting script to use 
+PsychicClubEntranceShouldRonaldAppear:
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
-	jr c, .asm_2cadc
+	jr c, .second_meeting
 	cp $03
-	jr c, .asm_2cae0
+	jr c, .third_meeting
 	cp $04
-	jr c, .asm_2caed
+	jr c, .fourth_meeting
 .asm_2cada
 	scf
 	ret
-.asm_2cadc
+.second_meeting ; second meeting - Ronald card pops with you
 	xor a
 	scf
 	ccf
 	ret
-.asm_2cae0
+.third_meeting ; after 2 GC pieces. Ronald gives you Super Energy Retrieval card
 	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2cada
@@ -486,7 +488,7 @@ Func_2cac8:
 	scf
 	ccf
 	ret
-.asm_2caed
+.fourth_meeting ; after 4 GR pieces. Ronald tells you he got the stolen cards back
 	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2cada
@@ -727,7 +729,7 @@ Func_2d399:
 	ret
 
 Func_2d3b5:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2d3c1
@@ -1002,7 +1004,7 @@ Func_2d9d8:
 	ret
 
 Func_2d9f4:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2da08
@@ -1270,7 +1272,7 @@ Func_2e115:
 	ret
 
 Func_2e131:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e145
@@ -1476,7 +1478,7 @@ Func_2e582:
 	ret
 
 Func_2e59e:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2e5b2
@@ -1794,7 +1796,7 @@ Func_2ed8c:
 	ret
 
 Func_2eda8:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2edbc
@@ -2111,7 +2113,7 @@ Func_2f5ae:
 	ret
 
 Func_2f5ca:
-	ld a, VAR_04
+	ld a, VAR_TIMES_RONALD_MET
 	farcall GetVarValue
 	cp $02
 	jr c, .asm_2f5de

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -1,10 +1,12 @@
 SECTION "Bank b@4000", ROMX[$4000], BANK[$b]
+
 Data_2c000:
 	db MAP_ISHIHARAS_HOUSE
 	dba Data_2c09b
 	db $23
 
 SECTION "Bank b@409b", ROMX[$409b], BANK[$b]
+
 Data_2c09b:
 	dbw $06, Func_2c0c1
 	dbw $08, Func_2c0f1
@@ -159,6 +161,7 @@ Func_2c1b8:
 ; 0x2c1db
 
 SECTION "Bank b@4479", ROMX[$4479], BANK[$b]
+
 Data_2c479:
 	db MAP_LIGHTNING_CLUB_1
 	dba Data_2c4c5
@@ -282,6 +285,7 @@ Data_2c936:
 
 
 SECTION "Bank b@4990", ROMX[$4990], BANK[$b]
+
 Data_2c990:
 	dbw $00, Func_2c9ac
 	dbw $06, Func_2c9d8
@@ -585,6 +589,7 @@ Func_2cbf5:
 	ret
 
 SECTION "Bank b@4d23", ROMX[$4d23], BANK[$b]
+
 Data_2cd23:
 	db MAP_PSYCHIC_CLUB
 	dba Data_2cd6f
@@ -629,6 +634,7 @@ Func_2cda2:
 ; TODO: function hangs when running tcg2disasm.py
 
 SECTION "Bank b@4e11", ROMX[$4e11], BANK[$b]
+
 Func_2ce11:
 	ld hl, $4d5a
 	call Func_328c
@@ -923,6 +929,7 @@ Data_2d930:
 	db $09
 
 SECTION "Bank b@596c", ROMX[$596c], BANK[$b]
+
 Data_2d96c:
 	dbw $06, Func_2d99f
 	dbw $09, Func_2d9d2
@@ -992,6 +999,7 @@ Func_2d9d2:
 	ret
 
 SECTION "Bank b@59d8", ROMX[$59d8], BANK[$b]
+
 Func_2d9d8:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
@@ -1174,6 +1182,7 @@ Func_2dd9c:
 ; 0x2dda2
 
 SECTION "Bank b@5ef2", ROMX[$5ef2], BANK[$b]
+
 Func_2def2:
 	dec b
 	xor c
@@ -1260,6 +1269,7 @@ Func_2e10f:
 ; 0x2e115
 
 SECTION "Bank b@6115", ROMX[$6115], BANK[$b]
+
 Func_2e115:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
@@ -1376,6 +1386,7 @@ Func_2e206:
 ; 0x2e211
 
 SECTION "Bank b@64b7", ROMX[$64b7], BANK[$b]
+
 Data_2e4b7:
 	db MAP_SCIENCE_CLUB_ENTRANCE
 	dba Data_2e4ff
@@ -1537,6 +1548,7 @@ Data_2e63f:
 	db $09
 
 SECTION "Bank b@66e1", ROMX[$66e1], BANK[$b]
+
 Data_2e6e1:
 	dbw $06, Func_2e71e
 	dbw $08, Func_2e72e
@@ -1604,6 +1616,7 @@ Func_2e73e:
 ; 0x2e749
 
 SECTION "Bank b@6752", ROMX[$6752], BANK[$b]
+
 Func_2e752:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
@@ -1620,12 +1633,14 @@ Func_2e752:
 ; 0x2e76e
 
 SECTION "Bank b@68e6", ROMX[$68e6], BANK[$b]
+
 Data_2e8e6:
 	db MAP_SCIENCE_CLUB
 	dba Data_2e932
 	db $0e
 
 SECTION "Bank b@6932", ROMX[$6932], BANK[$b]
+
 Data_2e932:
 	dbw $06, Func_2e955
 	dbw $08, Func_2e99f
@@ -1703,6 +1718,7 @@ Data_2ecc8:
 	db $09
 
 SECTION "Bank b@6d04", ROMX[$6d04], BANK[$b]
+
 Data_2ed04:
 	dbw $06, Func_2ed37
 	dbw $02, Func_2ed3e
@@ -1825,6 +1841,7 @@ Data_2edc5:
 	db $09
 
 SECTION "Bank b@6e5d", ROMX[$6e5d], BANK[$b]
+
 Data_2ee5d:
 	dbw $06, Func_2ee9a
 	dbw $08, Func_2eeaa
@@ -1892,6 +1909,7 @@ Func_2eeba:
 ; 0x2eec5
 
 SECTION "Bank b@6ece", ROMX[$6ece], BANK[$b]
+
 Func_2eece:
 	ld a, EVENT_MASONS_LAB_CHALLENGE_MACHINE_STATE_DUMMY
 	farcall GetEventValue
@@ -1915,6 +1933,7 @@ Data_2f012:
 	db $0c
 
 SECTION "Bank b@7072", ROMX[$7072], BANK[$b]
+
 Data_2f072:
 	dbw $06, Func_2f095
 	dbw $08, Func_2f0f7
@@ -2025,6 +2044,7 @@ Data_2f4ff:
 	db $09
 
 SECTION "Bank b@753b", ROMX[$753b], BANK[$b]
+
 Data_2f53b:
 	dbw $06, Func_2f56e
 	dbw $09, Func_2f5a8
@@ -2152,6 +2172,7 @@ Data_2f5fc:
 	db $09
 
 SECTION "Bank b@768a", ROMX[$768a], BANK[$b]
+
 Data_2f68a:
 	dbw $06, Func_2f6c7
 	dbw $08, Func_2f6d7
@@ -2237,6 +2258,7 @@ Data_2f7ca:
 	db $0e
 
 SECTION "Bank b@783b", ROMX[$783b], BANK[$b]
+
 Data_2f83b:
 	dbw $06, Func_2f85e
 	dbw $08, Func_2f8c8
@@ -2274,6 +2296,7 @@ Func_2f86e:
 
 
 SECTION "Bank b@78c8", ROMX[$78c8], BANK[$b]
+
 Func_2f8c8:
 	ld hl, $7801
 	call Func_328c
@@ -2301,6 +2324,7 @@ Data_2fcd5:
 	db $09
 
 SECTION "Bank b@7d66", ROMX[$7d66], BANK[$b]
+
 Data_2fd66:
 	dbw $06, Func_2fd83
 	dbw $08, Func_2fd93

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -479,7 +479,7 @@ Func_2cac8:
 	ccf
 	ret
 .asm_2cae0
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2cada
 	ld a, $01
@@ -487,7 +487,7 @@ Func_2cac8:
 	ccf
 	ret
 .asm_2caed
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2cada
 	ld a, $02
@@ -1019,7 +1019,7 @@ Func_2d9f4:
 	ccf
 	ret
 .asm_2da0c
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2da06
 	ld a, $01
@@ -1027,7 +1027,7 @@ Func_2d9f4:
 	ccf
 	ret
 .asm_2da19
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2da06
 	ld a, $02
@@ -1287,7 +1287,7 @@ Func_2e131:
 	ccf
 	ret
 .asm_2e149
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2e143
 	ld a, $01
@@ -1295,7 +1295,7 @@ Func_2e131:
 	ccf
 	ret
 .asm_2e156
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2e143
 	ld a, $02
@@ -1493,7 +1493,7 @@ Func_2e59e:
 	ccf
 	ret
 .asm_2e5b6
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2e5b0
 	ld a, $01
@@ -1501,7 +1501,7 @@ Func_2e59e:
 	ccf
 	ret
 .asm_2e5c3
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2e5b0
 	ld a, $02
@@ -2128,7 +2128,7 @@ Func_2f5ca:
 	ccf
 	ret
 .asm_2f5e2
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $02
 	jr nz, .asm_2f5dc
 	ld a, $01
@@ -2136,7 +2136,7 @@ Func_2f5ca:
 	ccf
 	ret
 .asm_2f5ef
-	farcall Func_c50b
+	farcall CountGRCoinPieces
 	cp $04
 	jr nz, .asm_2f5dc
 	ld a, $02

--- a/src/engine/bank0b.asm
+++ b/src/engine/bank0b.asm
@@ -1,0 +1,2398 @@
+SECTION "Bank b@4000", ROMX[$4000], BANK[$b]
+Data_2c000:
+    db MAP_ISHIHARAS_HOUSE
+    dba Data_2c09b
+    db $23
+
+SECTION "Bank b@409b", ROMX[$409b], BANK[$b]
+Data_2c09b:
+    dbw $06, Func_2c0c1
+    dbw $08, Func_2c0f1
+    dbw $07, Func_2c0c8
+    dbw $02, Func_2c0d1
+    dbw $0c, Func_2c101
+    dbw $0d, Func_2c12f
+    dbw $0b, Func_2c13e
+    dbw $01, Func_2c0b4
+    db $ff
+
+Func_2c0b4:
+	call Func_2c1b8
+	jr nc, .asm_2c0be
+	ld a, $09
+	ld [wd58e], a
+.asm_2c0be
+	scf
+	ccf
+	ret
+
+Func_2c0c1:
+	ld hl, $4005
+	call Func_324d
+	ret
+
+Func_2c0c8:
+	ld hl, $4018
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2c0d1:
+	xor a
+	call Func_33f2
+	ld h, h
+	ld de, $3e00
+	push af
+	farcall GetEventValue
+	jr z, .asm_2c0ef
+	ld a, $04
+	ld de, $102
+	farcall Func_10db8
+	ld b, $00
+	farcall Func_10dcf
+.asm_2c0ef
+	scf
+	ret
+
+Func_2c0f1:
+	ld hl, $4025
+	call Func_328c
+	jr nc, .asm_2c0ff
+	ld hl, $402e
+	call Func_32bf
+.asm_2c0ff
+	scf
+	ret
+
+Func_2c101:
+	xor a
+	push af
+	ld a, $f5
+	farcall GetEventValue
+	jr z, .asm_2c10f
+	pop af
+	or $01
+	push af
+.asm_2c10f
+	ld a, $f4
+	farcall GetEventValue
+	jr z, .asm_2c11b
+	pop af
+	or $02
+	push af
+.asm_2c11b
+	pop af
+	or a
+	jr z, .asm_2c12c
+	ld c, a
+	ld a, $00
+	farcall SetVarValue
+	ld a, $03
+	farcall MaxOutEventValue
+.asm_2c12c
+	scf
+	ccf
+	ret
+
+Func_2c12f:
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, $00
+	farcall ZeroOutVarValue
+	scf
+	ccf
+	ret
+
+Func_2c13e:
+	ld a, $f5
+	farcall ZeroOutEventValue
+	ld a, $00
+	farcall GetVarValue
+	bit 0, a
+	push af
+	call nz, Func_2c164
+	pop af
+	bit 1, a
+	call nz, Func_2c16b
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, $00
+	farcall ZeroOutVarValue
+	scf
+	ret
+
+Func_2c164:
+	ld a, $f5
+	farcall MaxOutEventValue
+	ret
+
+Func_2c16b:
+	ld a, $f4
+	farcall MaxOutEventValue
+	ret
+; 0x2c172
+
+SECTION "Bank b@41b8", ROMX[$41b8], BANK[$b]
+
+Func_2c1b8:
+	ld a, $02
+	farcall GetVarValue
+	cp $05
+	jr c, .asm_2c1d8
+	jr nz, .asm_2c1ce
+	ld a, $f4
+	farcall GetEventValue
+	jr nz, .asm_2c1d8
+	jr .asm_2c1d6
+.asm_2c1ce
+	ld a, $f5
+	farcall GetEventValue
+	jr nz, .asm_2c1d8
+.asm_2c1d6
+	scf
+	ret
+.asm_2c1d8
+	scf
+	ccf
+	ret
+; 0x2c1db
+
+SECTION "Bank b@4479", ROMX[$4479], BANK[$b]
+Data_2c479:
+    db MAP_LIGHTNING_CLUB_1
+    dba Data_2c4c5
+    db $0c
+
+
+SECTION "Bank b@44c5", ROMX[$44c5], BANK[$b]
+
+Data_2c4c5:
+    dbw $06, Func_2c4fa
+    dbw $08, Func_2c560
+    dbw $09, Func_2c568
+    dbw $07, Func_2c501
+    dbw $01, Func_2c4db
+    dbw $02, Func_2c50a
+    dbw $01, Func_2c4db
+    db $ff
+
+Func_2c4db:
+	ld a, EVENT_GOT_PIKACHU_COIN
+	farcall GetEventValue
+	jr nz, .asm_2c4ea
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2c4f7
+.asm_2c4ea
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2c4f7
+	ld a, $09
+	ld [wd58a], a
+.asm_2c4f7
+	scf
+	ccf
+	ret
+
+Func_2c4fa:
+	ld hl, $447e
+	call Func_324d
+	ret
+    
+Func_2c501:
+	ld hl, $4491
+	call Func_3205
+	scf
+	ccf
+	ret
+
+; TODO: this funtion's disasm is a little weird. may not be correct
+Func_2c50a:
+	ld a, EVENT_MET_GR4_LIGHTNING_CLUB
+	farcall GetEventValue
+	jr z, .asm_2c524
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2c54f
+	ld a, EVENT_GOT_PIKACHU_COIN
+	farcall GetEventValue
+	jr z, .asm_2c54f
+	jr .asm_2c55e
+.asm_2c524
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0b
+	ld [wd592], a
+	ld hl, $4584
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+	xor a
+	call Func_33f2
+	ld [hli], a
+	ld [hli], a
+	dec b
+	add hl, bc
+	ld [bc], a
+	ld [hli], a
+	inc h
+	ld [$209], sp
+	ld [hli], a
+	ld sp, DecompressData.get_sequence_len
+	ld [bc], a
+	nop
+	jr .asm_2c55e
+.asm_2c54f
+	xor a
+	call Func_33f2
+	ld [hli], a
+	ld [hli], a
+	dec b
+	ld b, $02
+	ld [hli], a
+	inc h
+	ld [$208], sp
+	nop
+.asm_2c55e
+	scf
+	ret
+
+Func_2c560:
+	ld hl, $44b0
+	call Func_328c
+	scf
+	ret
+
+Func_2c568:
+	ld hl, $4573
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2c573
+
+SECTION "Bank b@4936", ROMX[$4936], BANK[$b]
+
+Data_2c936:
+    db MAP_PSYCHIC_CLUB_ENTRANCE
+    dba Data_2c990
+    db $09
+
+
+SECTION "Bank b@4990", ROMX[$4990], BANK[$b]
+Data_2c990:
+    dbw $00, Func_2c9ac
+    dbw $06, Func_2c9d8
+    dbw $08, Func_2ca14
+    dbw $09, Func_2ca1c
+    dbw $07, Func_2c9df
+    dbw $02, Func_2c9e8
+    dbw $0b, Func_2ca22
+    dbw $01, Func_2c9b8
+    dbw $10, Func_2c9c8
+    db $ff
+
+Func_2c9ac:
+	call Func_3332
+	call Func_2ca46
+	call Func_32d8
+	scf
+	ccf
+	ret
+
+Func_2c9b8:
+	ld a, $0f
+	farcall GetEventValue
+	jr nz, .asm_2c9c5
+	ld a, $14
+	ld [wd58e], a
+.asm_2c9c5
+	scf
+	ccf
+	ret
+Func_2c9c8:
+	call Func_2cac8
+	jr nc, .asm_2c9cf
+	scf
+	ret
+.asm_2c9cf
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2c9d8:
+	ld hl, $493b
+	call Func_324d
+	ret
+Func_2c9df:
+	ld hl, $4984
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2c9e8:
+	call Func_2cac8
+	jr c, .asm_2ca12
+	cp $01
+	jr z, .asm_2c9f8
+	jr nc, .asm_2c9fd
+	ld hl, $4037
+	jr .asm_2ca00
+.asm_2c9f8
+	ld hl, $417e
+	jr .asm_2ca00
+.asm_2c9fd
+	ld hl, $41f7
+.asm_2ca00
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2ca12
+	scf
+	ret
+
+Func_2ca14:
+	ld hl, $498b
+	call Func_328c
+	scf
+	ret
+Func_2ca1c:
+	farcall Func_341c4
+	scf
+	ret
+
+Func_2ca22:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2ca3c
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2ca3c
+	scf
+	ret
+
+Func_2ca3e:
+	call Func_2ca46
+	farcall Func_c199
+	ret
+
+Func_2ca46:
+	ld a, EVENT_GOT_PIKACHU_COIN
+	farcall GetEventValue
+	jr nz, .asm_2ca9f
+	ldh a, [hKeysHeld]
+	bit 6, a
+	jr z, .asm_2ca9f
+	ld a, [wPlayerOWObject]
+	ld b, $00
+	farcall Func_10dcf
+	farcall Func_10da7
+	ld a, $02
+	cp e
+	jr nz, .asm_2ca9f
+	ld a, $04
+	cp d
+	jr z, .asm_2ca86
+	ld a, $05
+	cp d
+	jr nz, .asm_2ca9f
+	ld a, $29
+	farcall Func_10da7
+	ld a, $05
+	cp d
+	jr z, .asm_2ca9f
+	ld a, $29
+	ld bc, $8101
+	farcall Func_10e3c
+	jr .asm_2ca9a
+.asm_2ca86
+	ld a, $29
+	farcall Func_10da7
+	ld a, $04
+	cp d
+	jr z, .asm_2ca9f
+	ld a, $29
+	ld bc, $8301
+	farcall Func_10e3c
+.asm_2ca9a
+	ld a, $29
+	call Func_336d
+.asm_2ca9f
+	ret
+
+Func_2caa0:
+	ld a, $29
+	ld [$d60e], a
+	ld hl, $9f3
+	ld a, l
+	ld [$d60f], a
+	ld a, h
+	ld [$d610], a
+	xor a
+	call Func_33f2
+	ld bc, $cb05
+	dec bc
+	ld [bc], a
+	nop
+	ret
+
+Func_2cabb:
+	ld a, EVENT_GOT_PIKACHU_COIN
+	farcall GetEventValue
+	jr z, .asm_2cac5
+	scf
+	ret
+.asm_2cac5
+	scf
+	ccf
+	ret
+
+Func_2cac8:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2cadc
+	cp $03
+	jr c, .asm_2cae0
+	cp $04
+	jr c, .asm_2caed
+.asm_2cada
+	scf
+	ret
+.asm_2cadc
+	xor a
+	scf
+	ccf
+	ret
+.asm_2cae0
+	farcall Func_c50b
+	cp $02
+	jr nz, .asm_2cada
+	ld a, $01
+	scf
+	ccf
+	ret
+.asm_2caed
+	farcall Func_c50b
+	cp $04
+	jr nz, .asm_2cada
+	ld a, $02
+	scf
+	ccf
+	ret
+
+Data_2cafa:
+    db MAP_PSYCHIC_CLUB_LOBBY
+    dba Data_2cb92
+    db $09
+
+SECTION "Bank b@4b92", ROMX[$4b92], BANK[$b]
+
+Data_2cb92:
+    dbw $06, Func_2cbcf
+    dbw $08, Func_2cbdf
+    dbw $07, Func_2cbd6
+    dbw $09, Func_2cbef
+    dbw $0b, Func_2cbf5
+    dbw $01, Func_2cba8
+    dbw $10, Func_2cbba
+    db $ff
+
+Func_2cba8:
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
+	farcall GetEventValue
+	jr nz, .asm_2cbb7
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2cbb7
+.asm_2cbb7
+	scf
+	ccf
+	ret
+
+Func_2cbba:
+	ld a, $25
+	farcall GetVarValue
+	cp $03
+	jr z, .asm_2cbc6
+	scf
+	ret
+.asm_2cbc6
+	ld a, $10
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2cbcf:
+	ld hl, $4aff
+	call Func_324d
+	ret
+
+Func_2cbd6:
+	ld hl, $4b12
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2cbdf:
+	ld hl, $4b3d
+	call Func_328c
+	jr nc, .asm_2cbed
+	ld hl, $4b52
+	call Func_32bf
+.asm_2cbed
+	scf
+	ret
+
+Func_2cbef:
+	farcall Func_3c3ca
+	scf
+	ret
+
+Func_2cbf5:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2cc0f
+	ld a, $05
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2cc0f
+	scf
+	ret
+
+SECTION "Bank b@4d23", ROMX[$4d23], BANK[$b]
+Data_2cd23:
+	db MAP_PSYCHIC_CLUB
+	dba Data_2cd6f
+	db $0d
+
+SECTION "Bank b@4d6f", ROMX[$4d6f], BANK[$b]
+
+Data_2cd6f:
+    dbw $06, Func_2cd92
+    dbw $08, Func_2ce11
+    dbw $09, Func_2ce19
+    dbw $07, Func_2cd99
+    dbw $02, Func_2cda2
+    dbw $01, Func_2cd82
+    db $ff
+
+Func_2cd82:
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
+	farcall GetEventValue
+	jr nz, .asm_2cd8f
+	ld a, $14
+	ld [wd58e], a
+.asm_2cd8f
+	scf
+	ccf
+	ret
+
+Func_2cd92:
+	ld hl, $4d28
+	call Func_324d
+	ret
+
+Func_2cd99:
+	ld hl, $4d3b
+	call Func_3205
+	scf
+	ccf
+	ret
+; 0x2cda2
+
+Func_2cda2:
+; TODO: function hangs when running tcg2disasm.py
+
+SECTION "Bank b@4e11", ROMX[$4e11], BANK[$b]
+Func_2ce11:
+	ld hl, $4d5a
+	call Func_328c
+	scf
+	ret
+
+Func_2ce19:
+	ld hl, $4e24
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+
+SECTION "Bank b@523c", ROMX[$523c], BANK[$b]
+
+Func_2d23c:
+	ld a, EVENT_GOT_GR_COIN_PIECE_BOTTOM_RIGHT
+	farcall GetEventValue
+	jr z, .asm_2d246
+	scf
+	ret
+.asm_2d246
+	scf
+	ccf
+	ret
+; 0x2d249
+
+SECTION "Bank b@530a", ROMX[$530a], BANK[$b]
+
+Data_2d30a:
+	db MAP_ROCK_CLUB_ENTRANCE
+	dba Data_2d346
+	db $09
+
+SECTION "Bank b@5346", ROMX[$5346], BANK[$b]
+
+Data_2d346:
+	dbw $06, Func_2d376
+	dbw $02, Func_2d37d
+	dbw $0b, Func_2d399
+	dbw $01, Func_2d356
+	dbw $10, Func_2d366
+	db $ff
+
+Func_2d356:
+	ld a, $98
+	farcall GetEventValue
+	jr nz, .asm_2d363
+	ld a, $14
+	ld [wd58e], a
+.asm_2d363
+	scf
+	ccf
+	ret
+
+Func_2d366:
+	call Func_2d3b5
+	jr nc, .asm_2d36d
+	scf
+	ret
+.asm_2d36d
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2d376:
+	ld hl, $530f
+	call Func_324d
+	ret
+
+Func_2d37d:
+	call Func_2d3b5
+	jr c, .asm_2d397
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld hl, $4111
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2d397
+	scf
+	ret
+
+Func_2d399:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2d3b3
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2d3b3
+	scf
+	ret
+
+Func_2d3b5:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2d3c1
+	scf
+	ret
+.asm_2d3c1
+	scf
+	ccf
+	ret
+
+Data_2d3c4:
+	db MAP_ROCK_CLUB_LOBBY
+	dba Data_2d45c
+	db $09
+
+SECTION "Bank b@545c", ROMX[$545c], BANK[$b]
+
+Data_2d45c:
+	dbw $06, Func_2d49e
+	dbw $08, Func_2d4ae
+	dbw $07, Func_2d4a5
+	dbw $09, Func_2d4be
+	dbw $0b, Func_2d4c4
+	dbw $01, Func_2d472
+	dbw $10, Func_2d489
+	db $ff
+
+Func_2d472:
+	ld a, $98
+	farcall GetEventValue
+	jr nz, .asm_2d486
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2d486
+	ld a, $10
+	ld [wd58e], a
+.asm_2d486
+	scf
+	ccf
+	ret
+
+Func_2d489:
+	ld a, $25
+	farcall GetVarValue
+	cp $04
+	jr z, .asm_2d495
+	scf
+	ret
+.asm_2d495
+	ld a, $10
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2d49e:
+	ld hl, $53c9
+	call Func_324d
+	ret
+
+Func_2d4a5:
+	ld hl, $53dc
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2d4ae:
+	ld hl, $5407
+	call Func_328c
+	jr nc, .asm_2d4bc
+	ld hl, $541c
+	call Func_32bf
+.asm_2d4bc
+	scf
+	ret
+
+Func_2d4be:
+	farcall Func_3c3ca
+	scf
+	ret
+
+Func_2d4c4:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2d4de
+	ld a, $05
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2d4de
+	scf
+	ret
+; 0x2d4e0
+
+SECTION "Bank b@55f8", ROMX[$55f8], BANK[$b]
+
+Data_2d5f8:
+	db MAP_ROCK_CLUB
+	dba Data_2d640
+	db $0d
+
+SECTION "Bank b@5640", ROMX[$5640], BANK[$b]
+
+Data_2d640:
+	dbw $06, Func_2d663
+	dbw $08, Func_2d6a6
+	dbw $07, Func_2d66a
+	dbw $02, Func_2d673
+	dbw $09, Func_2d6ae
+	dbw $01, Func_2d653
+	db $ff
+
+Func_2d653:
+	ld a, $98
+	farcall GetEventValue
+	jr nz, .asm_2d660
+	ld a, $14
+	ld [wd58e], a
+.asm_2d660
+	scf
+	ccf
+	ret
+
+Func_2d663:
+	ld hl, $55fd
+	call Func_324d
+	ret
+
+Func_2d66a:
+	ld hl, $5610
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2d673:
+	ld a, $98
+	farcall GetEventValue
+	jr nz, .asm_2d6a4
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0b
+	ld [wd592], a
+	ld hl, $56ca
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+	xor a
+	call Func_33f2
+	ld [hli], a
+	ld a, [bc]
+	dec b
+	ld bc, $2202
+	dec bc
+	ld [$201], sp
+	ld [hli], a
+	inc c
+	ld b, $01
+	ld [bc], a
+	nop
+.asm_2d6a4
+	scf
+	ret
+
+Func_2d6a6:
+	ld hl, $562f
+	call Func_328c
+	scf
+	ret
+
+Func_2d6ae:
+	ld hl, $56b9
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2d6b9
+
+SECTION "Bank b@5930", ROMX[$5930], BANK[$b]
+
+Data_2d930:
+	db MAP_FIGHTING_CLUB_ENTRANCE
+	dba Data_2d96c
+	db $09
+
+SECTION "Bank b@596c", ROMX[$596c], BANK[$b]
+Data_2d96c:
+	dbw $06, Func_2d99f
+	dbw $09, Func_2d9d2
+	dbw $02, Func_2d9a6
+	dbw $0b, Func_2d9d8
+	dbw $01, Func_2d97f
+	dbw $10, Func_2d98f
+	db $ff
+
+Func_2d97f:
+	ld a, $0c
+	farcall GetEventValue
+	jr nz, .asm_2d98c
+	ld a, $14
+	ld [wd58e], a
+.asm_2d98c
+	scf
+	ccf
+	ret
+	
+Func_2d98f:
+	call Func_2d9f4
+	jr nc, .asm_2d996
+	scf
+	ret
+.asm_2d996
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2d99f:
+	ld hl, $5935
+	call Func_324d
+	ret
+
+Func_2d9a6:
+	call Func_2d9f4
+	jr c, .asm_2d9d0
+	cp $01
+	jr z, .asm_2d9b6
+	jr nc, .asm_2d9bb
+	ld hl, $4037
+	jr .asm_2d9be
+.asm_2d9b6
+	ld hl, $417e
+	jr .asm_2d9be
+.asm_2d9bb
+	ld hl, $41f7
+.asm_2d9be
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2d9d0
+	scf
+	ret
+
+Func_2d9d2:
+	farcall Func_341c4
+	scf
+	ret
+
+SECTION "Bank b@59d8", ROMX[$59d8], BANK[$b]
+Func_2d9d8:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2d9f2
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2d9f2
+	scf
+	ret
+
+Func_2d9f4:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2da08
+	cp $03
+	jr c, .asm_2da0c
+	cp $04
+	jr c, .asm_2da19
+.asm_2da06
+	scf
+	ret
+.asm_2da08
+	xor a
+	scf
+	ccf
+	ret
+.asm_2da0c
+	farcall Func_c50b
+	cp $02
+	jr nz, .asm_2da06
+	ld a, $01
+	scf
+	ccf
+	ret
+.asm_2da19
+	farcall Func_c50b
+	cp $04
+	jr nz, .asm_2da06
+	ld a, $02
+	scf
+	ccf
+	ret
+
+Data_2da26:
+	db MAP_FIGHTING_CLUB_LOBBY
+	dba Data_d2abe
+	db $09
+
+SECTION "Bank b@5abe", ROMX[$5abe], BANK[$b]
+
+Data_d2abe:
+	dbw $06, Func_2dade
+	dbw $08, Func_2daee
+	dbw $07, Func_2dae5
+	dbw $09, Func_2dafe
+	dbw $01, Func_2dace
+	db $ff
+Func_2dace:
+	ld a, $0c
+	farcall GetEventValue
+	jr nz, .asm_2dadb
+	ld a, $14
+	ld [wd58e], a
+.asm_2dadb
+	scf
+	ccf
+	ret
+	
+Func_2dade:
+	ld hl, $5a2b
+	call Func_324d
+	ret
+
+Func_2dae5:
+	ld hl, $5a3e
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2daee:
+	ld hl, $5a69
+	call Func_328c
+	jr nc, .asm_2dafc
+	ld hl, $5a7e
+	call Func_32bf
+.asm_2dafc
+	scf
+	ret
+
+Func_2dafe:
+	ld hl, $5b09
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2db09
+
+SECTION "Bank b@5c9f", ROMX[$5c9f], BANK[$b]
+
+Data_2dc9f:
+	db MAP_FIGHTING_CLUB
+	dba Data_2dceb
+	db $0e
+
+SECTION "Bank b@5ceb", ROMX[$5ceb], BANK[$b]
+
+Data_2dceb:
+	dbw $06, Func_2dd0e
+	dbw $08, Func_2dd3a
+	dbw $07, Func_2dd31
+	dbw $09, Func_2dd42
+	dbw $02, Func_2dd15
+	dbw $01, Func_2dcfe
+	db $ff
+
+Func_2dcfe:
+	ld a, $0c
+	farcall GetEventValue
+	jr nz, .asm_2dd0b
+	ld a, $14
+	ld [wd58e], a
+.asm_2dd0b
+	scf
+	ccf
+	ret
+
+Func_2dd0e:
+	ld hl, $5ca4
+	call Func_324d
+	ret
+
+Func_2dd15:
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2dd2f
+	ld a, $0c
+	farcall GetEventValue
+	jr z, .asm_2dd2f
+	ld bc, $1a
+	ld de, $500
+	farcall Func_12c0ce
+.asm_2dd2f
+	scf
+	ret
+
+Func_2dd31:
+	ld hl, $5cb7
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2dd3a:
+	ld hl, $5cd6
+	call Func_328c
+	scf
+	ret
+
+Func_2dd42:
+	ld hl, $5d4d
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2dd4d
+
+SECTION "Bank b@5d9c", ROMX[$5d9c], BANK[$b]
+
+Func_2dd9c:
+	dec b
+	sub b
+	ld [$2], sp
+	ret
+; 0x2dda2
+
+SECTION "Bank b@5ef2", ROMX[$5ef2], BANK[$b]
+Func_2def2:
+	dec b
+	xor c
+	ld [$2], sp
+	ret
+; 0x2def8
+
+SECTION "Bank b@606d", ROMX[$606d], BANK[$b]
+
+Data_2e06d:
+	db MAP_GRASS_CLUB_ENTRANCE
+	dba Data_2e0a9
+	db $09
+
+SECTION "Bank b@60a9", ROMX[$60a9], BANK[$b]
+
+Data_2e0a9:
+	dbw $06, Func_2e0dc
+	dbw $09, Func_2e10f
+	dbw $02, Func_2e0e3
+	dbw $0b, Func_2e115
+	dbw $01, Func_2e0bc
+	dbw $10, Func_2e0cc
+	db $ff
+
+Func_2e0bc:
+	ld a, $0d
+	farcall GetEventValue
+	jr nz, .asm_2e0c9
+	ld a, $14
+	ld [wd58e], a
+.asm_2e0c9
+	scf
+	ccf
+	ret
+
+Func_2e0cc:
+	call Func_2e131
+	jr nc, .asm_2e0d3
+	scf
+	ret
+.asm_2e0d3
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2e0dc:
+	ld hl, $6072
+	call Func_324d
+	ret
+
+Func_2e0e3:
+	call Func_2e131
+	jr c, .asm_2e10d
+	cp $01
+	jr z, .asm_2e0f3
+	jr nc, .asm_2e0f8
+	ld hl, $4037
+	jr .asm_2e0fb
+.asm_2e0f3
+	ld hl, $417e
+	jr .asm_2e0fb
+.asm_2e0f8
+	ld hl, $41f7
+.asm_2e0fb
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2e10d
+	scf
+	ret
+
+Func_2e10f:
+	farcall Func_341c4
+	scf
+	ret
+; 0x2e115
+
+SECTION "Bank b@6115", ROMX[$6115], BANK[$b]
+
+Func_2e115:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2e12f
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2e12f
+	scf
+	ret
+
+Func_2e131:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2e145
+	cp $03
+	jr c, .asm_2e149
+	cp $04
+	jr c, .asm_2e156
+.asm_2e143
+	scf
+	ret
+.asm_2e145
+	xor a
+	scf
+	ccf
+	ret
+.asm_2e149
+	farcall Func_c50b
+	cp $02
+	jr nz, .asm_2e143
+	ld a, $01
+	scf
+	ccf
+	ret
+.asm_2e156
+	farcall Func_c50b
+	cp $04
+	jr nz, .asm_2e143
+	ld a, $02
+	scf
+	ccf
+	ret
+
+Data_2e163:
+	db MAP_GRASS_CLUB
+	dba Data_2e1af
+	db $0c
+
+SECTION "Bank b@61af", ROMX[$61af], BANK[$b]
+
+Data_2e1af:
+	dbw $06, Func_2e1d2
+	dbw $08, Func_2e1fe
+	dbw $09, Func_2e206
+	dbw $02, Func_2e1d9
+	dbw $07, Func_2e1f5
+	dbw $01, Func_2e1c2
+	db $ff
+
+Func_2e1c2:
+	ld a, $0d
+	farcall GetEventValue
+	jr nz, .asm_2e1cf
+	ld a, $14
+	ld [wd58e], a
+.asm_2e1cf
+	scf
+	ccf
+	ret
+
+Func_2e1d2:
+	ld hl, $6168
+	call Func_324d
+	ret
+
+Func_2e1d9:
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2e1f3
+	ld a, $0d
+	farcall GetEventValue
+	jr z, .asm_2e1f3
+	ld bc, $1e
+	ld de, $50b
+	farcall Func_12c0ce
+.asm_2e1f3
+	scf
+	ret
+
+Func_2e1f5:
+	ld hl, $617b
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2e1fe:
+	ld hl, $619a
+	call Func_328c
+	scf
+	ret
+
+Func_2e206:
+	ld hl, $6211
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2e211
+
+SECTION "Bank b@64b7", ROMX[$64b7], BANK[$b]
+Data_2e4b7:
+	db MAP_SCIENCE_CLUB_ENTRANCE
+	dba Data_2e4ff
+	db $09
+
+SECTION "Bank b@64ff", ROMX[$64ff], BANK[$b]
+
+Data_2e4ff:
+	dbw $06, Func_2e538
+	dbw $08, Func_2e574
+	dbw $09, Func_2e57c
+	dbw $07, Func_2e53f
+	dbw $02, Func_2e548
+	dbw $0b, Func_2e582
+	dbw $01, Func_2e518
+	dbw $10, Func_2e528
+	db $ff
+
+Func_2e518:
+	ld a, $0d
+	farcall GetEventValue
+	jr nz, .asm_2e525
+	ld a, $14
+	ld [wd58e], a
+.asm_2e525
+	scf
+	ccf
+	ret
+
+Func_2e528:
+	call Func_2e59e
+	jr nc, .asm_2e52f
+	scf
+	ret
+.asm_2e52f
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2e538:
+	ld hl, $64bc
+	call Func_324d
+	ret
+
+Func_2e53f:
+	ld hl, $64f3
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2e548:
+	call Func_2e59e
+	jr c, .asm_2e572
+	cp $01
+	jr z, .asm_2e558
+	jr nc, .asm_2e55d
+	ld hl, $4037
+	jr .asm_2e560
+.asm_2e558
+	ld hl, $417e
+	jr .asm_2e560
+.asm_2e55d
+	ld hl, $41f7
+.asm_2e560
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2e572
+	scf
+	ret
+
+Func_2e574:
+	ld hl, $64fa
+	call Func_328c
+	scf
+	ret
+
+Func_2e57c:
+	farcall Func_341c4
+	scf
+	ret
+
+Func_2e582:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2e59c
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2e59c
+	scf
+	ret
+
+Func_2e59e:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2e5b2
+	cp $03
+	jr c, .asm_2e5b6
+	cp $04
+	jr c, .asm_2e5c3
+.asm_2e5b0
+	scf
+	ret
+.asm_2e5b2
+	xor a
+	scf
+	ccf
+	ret
+.asm_2e5b6
+	farcall Func_c50b
+	cp $02
+	jr nz, .asm_2e5b0
+	ld a, $01
+	scf
+	ccf
+	ret
+.asm_2e5c3
+	farcall Func_c50b
+	cp $04
+	jr nz, .asm_2e5b0
+	ld a, $02
+	scf
+	ccf
+	ret
+; 0x2e5d0
+
+SECTION "Bank b@662a", ROMX[$662a], BANK[$b]
+
+Func_2e62a:
+	ld a, $0d
+	farcall GetEventValue
+	jr z, .asm_2e63c
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2e63c
+	scf
+	ret
+.asm_2e63c
+	scf
+	ccf
+	ret
+
+Data_2e63f:
+	db MAP_SCIENCE_CLUB_LOBBY
+	dba Data_2e6e1
+	db $09
+
+SECTION "Bank b@66e1", ROMX[$66e1], BANK[$b]
+Data_2e6e1:
+	dbw $06, Func_2e71e
+	dbw $08, Func_2e72e
+	dbw $09, Func_2e73e
+	dbw $07, Func_2e725
+	dbw $0b, Func_2e752
+	dbw $01, Func_2e6f7
+	dbw $10, Func_2e709
+	db $ff
+
+Func_2e6f7:
+	ld a, $0d
+	farcall GetEventValue
+	jr nz, .asm_2e706
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2e706
+.asm_2e706
+	scf
+	ccf
+	ret
+
+Func_2e709:
+	ld a, $25
+	farcall GetVarValue
+	cp $07
+	jr z, .asm_2e715
+	scf
+	ret
+.asm_2e715
+	ld a, $10
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2e71e:
+	ld hl, $6644
+	call Func_324d
+	ret
+
+Func_2e725:
+	ld hl, $6657
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2e72e:
+	ld hl, $6688
+	call Func_328c
+	jr nc, .asm_2e73c
+	ld hl, $66a1
+	call Func_32bf
+.asm_2e73c
+	scf
+	ret
+
+Func_2e73e:
+	ld hl, $6749
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2e749
+
+SECTION "Bank b@6752", ROMX[$6752], BANK[$b]
+Func_2e752:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2e76c
+	ld a, $05
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2e76c
+	scf
+	ret
+; 0x2e76e
+
+SECTION "Bank b@68e6", ROMX[$68e6], BANK[$b]
+Data_2e8e6:
+	db MAP_SCIENCE_CLUB
+	dba Data_2e932
+	db $0e
+
+SECTION "Bank b@6932", ROMX[$6932], BANK[$b]
+Data_2e932:
+	dbw $06, Func_2e955
+	dbw $08, Func_2e99f
+	dbw $09, Func_2e9a7
+	dbw $02, Func_2e95c
+	dbw $07, Func_2e996
+	dbw $01, Func_2e945
+	db $ff
+
+Func_2e945:
+	ld a, $0d
+	farcall GetEventValue
+	jr nz, .asm_2e952
+	ld a, $14
+	ld [wd58e], a
+.asm_2e952
+	scf
+	ccf
+	ret
+Func_2e955:
+	ld hl, $68eb
+	call Func_324d
+	ret
+
+Func_2e95c:
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2e994
+	ld a, $0d
+	farcall GetEventValue
+	jr z, .asm_2e994
+	ld bc, $22
+	ld de, $401
+	farcall Func_12c0ce
+	ld bc, $23
+	ld de, $901
+	farcall Func_12c0ce
+	ld bc, $24
+	ld de, SetBGP
+	farcall Func_12c0ce
+	ld bc, $25
+	ld de, $50c
+	farcall Func_12c0ce
+.asm_2e994
+	scf
+	ret
+
+Func_2e996:
+	ld hl, $68fe
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2e99f:
+	ld hl, $691d
+	call Func_328c
+	scf
+	ret
+
+Func_2e9a7:
+	ld hl, $69b2
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2e9b2
+
+SECTION "Bank b@6cc8", ROMX[$6cc8], BANK[$b]
+
+Data_2ecc8:
+	db MAP_WATER_CLUB_ENTRANCE
+	dba Data_2ed04
+	db $09
+
+SECTION "Bank b@6d04", ROMX[$6d04], BANK[$b]
+Data_2ed04:
+	dbw $06, Func_2ed37
+	dbw $02, Func_2ed3e
+	dbw $04, Func_2ed75
+	dbw $0b, Func_2ed8c
+	dbw $01, Func_2ed17
+	dbw $10, Func_2ed27
+	db $ff
+
+Func_2ed17:
+	ld a, $07
+	farcall GetEventValue
+	jr nz, .asm_2ed24
+	ld a, $14
+	ld [wd58e], a
+.asm_2ed24
+	scf
+	ccf
+	ret
+; 0x2ed27
+
+Func_2ed27:
+	call Func_2eda8
+	jr nc, .asm_2ed2e
+	scf
+	ret
+.asm_2ed2e
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2ed37:
+	ld hl, $6ccd
+	call Func_324d
+	ret
+
+Func_2ed3e:
+	xor a
+	call Func_33f2
+	ld h, h
+	ld [de], a
+	nop
+	call Func_2eda8
+	jr c, .asm_2ed73
+	or a
+	jr nz, .asm_2ed58
+	ld hl, $a2a
+	call LoadTxRam2
+	ld hl, $40a4
+	jr .asm_2ed61
+.asm_2ed58
+	ld a, $ee
+	farcall ZeroOutEventValue
+	ld hl, $451d
+.asm_2ed61
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2ed73
+	scf
+	ret
+
+Func_2ed75:
+	ld a, $ed
+	farcall GetEventValue
+	jr z, .asm_2ed8a
+	ld a, [wd585]
+	cp $00
+	jr nz, .asm_2ed8a
+	ld a, $33
+	farcall ZeroOutEventValue
+.asm_2ed8a
+	scf
+	ret
+
+Func_2ed8c:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2eda6
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2eda6
+	scf
+	ret
+
+Func_2eda8:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2edbc
+	ld a, $ee
+	farcall GetEventValue
+	jr nz, .asm_2edc0
+	scf
+	ret
+.asm_2edbc
+	xor a
+	scf
+	ccf
+	ret
+.asm_2edc0
+	ld a, $01
+	scf
+	ccf
+	ret
+
+Data_2edc5:
+	db MAP_WATER_CLUB_LOBBY
+	dba Data_2ee5d
+	db $09
+
+SECTION "Bank b@6e5d", ROMX[$6e5d], BANK[$b]
+Data_2ee5d:
+	dbw $06, Func_2ee9a
+	dbw $08, Func_2eeaa
+	dbw $09, Func_2eeba
+	dbw $07, Func_2eea1
+	dbw $0b, Func_2eece
+	dbw $01, Func_2ee73
+	dbw $10, Func_2ee85
+	db $ff
+
+Func_2ee73:
+	ld a, $07
+	farcall GetEventValue
+	jr nz, .asm_2ee82
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2ee82
+.asm_2ee82
+	scf
+	ccf
+	ret
+
+Func_2ee85:
+	ld a, $25
+	farcall GetVarValue
+	cp $08
+	jr z, .asm_2ee91
+	scf
+	ret
+.asm_2ee91
+	ld a, $10
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2ee9a:
+	ld hl, $6dca
+	call Func_324d
+	ret
+
+Func_2eea1:
+	ld hl, $6ddd
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2eeaa:
+	ld hl, $6e08
+	call Func_328c
+	jr nc, .asm_2eeb8
+	ld hl, $6e1d
+	call Func_32bf
+.asm_2eeb8
+	scf
+	ret
+
+Func_2eeba:
+	ld hl, $6ec5
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2eec5
+
+SECTION "Bank b@6ece", ROMX[$6ece], BANK[$b]
+Func_2eece:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2eee8
+	ld a, $05
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2eee8
+	scf
+	ret
+; 0x2eeea
+
+SECTION "Bank b@7012", ROMX[$7012], BANK[$b]
+
+Data_2f012:
+	db MAP_WATER_CLUB
+	dba Data_2f072
+	db $0c
+
+SECTION "Bank b@7072", ROMX[$7072], BANK[$b]
+Data_2f072:
+	dbw $06, Func_2f095
+	dbw $08, Func_2f0f7
+	dbw $02, Func_2f0a5
+	dbw $09, Func_2f107
+	dbw $07, Func_2f09c
+	dbw $01, Func_2f085
+	db $ff
+
+Func_2f085:
+	ld a, $07
+	farcall GetEventValue
+	jr nz, .asm_2f092
+	ld a, $14
+	ld [wd58e], a
+.asm_2f092
+	scf
+	ccf
+	ret
+
+Func_2f095:
+	ld hl, $7017
+	call Func_324d
+	ret
+
+Func_2f09c:
+	ld hl, $702a
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2f0a5:
+	ld a, $07
+	farcall GetEventValue
+	jr nz, .asm_2f0c3
+	xor a
+	call Func_33f2
+	dec d
+	xor h
+	inc b
+	ld b, $02
+	dec d
+	xor l
+	inc bc
+	ld b, $01
+	dec d
+	xor [hl]
+	dec b
+	ld b, $03
+	nop
+	jr .asm_2f0f5
+.asm_2f0c3
+	ld bc, $2a
+	ld de, $204
+	farcall Func_12c0ce
+	ld a, $ed
+	farcall GetEventValue
+	jr nz, .asm_2f0e1
+	ld bc, $29
+	ld de, $50c
+	farcall Func_12c0ce
+	jr .asm_2f0f5
+.asm_2f0e1
+	xor a
+	call Func_33f2
+	ld [hli], a
+	add hl, de
+	add hl, bc
+	dec b
+	ld [bc], a
+	ld [hli], a
+	inc e
+	ld [$205], sp
+	ld [hli], a
+	dec e
+	ld a, [bc]
+	dec b
+	ld [bc], a
+	nop
+.asm_2f0f5
+	scf
+	ret
+
+Func_2f0f7:
+	ld hl, $704f
+	call Func_328c
+	jr nc, .asm_2f105
+	ld hl, $7068
+	call Func_32bf
+.asm_2f105
+	scf
+	ret
+
+Func_2f107:
+	ld hl, Func_2f112
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+
+Func_2f112:
+; TODO: this function doesn't want to disasm cleanly, but is
+; required in Func_2f107
+
+SECTION "Bank b@74ff", ROMX[$74ff], BANK[$b]
+
+Data_2f4ff:
+	db MAP_FIRE_CLUB_ENTRANCE
+	dba Data_2f53b
+	db $09
+
+SECTION "Bank b@753b", ROMX[$753b], BANK[$b]
+Data_2f53b:
+	dbw $06, Func_2f56e
+	dbw $09, Func_2f5a8
+	dbw $02, Func_2f575
+	dbw $0b, Func_2f5ae
+	dbw $01, Func_2f54e
+	dbw $10, Func_2f55e
+	db $ff
+
+Func_2f54e:
+	ld a, $0e
+	farcall GetEventValue
+	jr nz, .asm_2f55b
+	ld a, $14
+	ld [wd58e], a
+.asm_2f55b
+	scf
+	ccf
+	ret
+
+Func_2f55e:
+	call Func_2f5ca
+	jr nc, .asm_2f565
+	scf
+	ret
+.asm_2f565
+	ld a, $0f
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2f56e:
+	ld hl, $7504
+	call Func_324d
+	ret
+
+Func_2f575:
+	xor a
+	call Func_33f2
+	ld h, h
+	ld [de], a
+	nop
+	call Func_2f5ca
+	jr c, .asm_2f5a6
+	cp $01
+	jr z, .asm_2f58c
+	jr nc, .asm_2f591
+	ld hl, $4037
+	jr .asm_2f594
+.asm_2f58c
+	ld hl, $417e
+	jr .asm_2f594
+.asm_2f591
+	ld hl, $41f7
+.asm_2f594
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0d
+	ld [wd592], a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+.asm_2f5a6
+	scf
+	ret
+
+Func_2f5a8:
+	farcall Func_341c4
+	scf
+	ret
+
+Func_2f5ae:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2f5c8
+	ld a, $03
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2f5c8
+	scf
+	ret
+
+Func_2f5ca:
+	ld a, $04
+	farcall GetVarValue
+	cp $02
+	jr c, .asm_2f5de
+	cp $03
+	jr c, .asm_2f5e2
+	cp $04
+	jr c, .asm_2f5ef
+.asm_2f5dc
+	scf
+	ret
+.asm_2f5de
+	xor a
+	scf
+	ccf
+	ret
+.asm_2f5e2
+	farcall Func_c50b
+	cp $02
+	jr nz, .asm_2f5dc
+	ld a, $01
+	scf
+	ccf
+	ret
+.asm_2f5ef
+	farcall Func_c50b
+	cp $04
+	jr nz, .asm_2f5dc
+	ld a, $02
+	scf
+	ccf
+	ret
+
+Data_2f5fc:
+	db MAP_FIRE_CLUB_LOBBY
+	dba Data_2f68a
+	db $09
+
+SECTION "Bank b@768a", ROMX[$768a], BANK[$b]
+Data_2f68a:
+	dbw $06, Func_2f6c7
+	dbw $08, Func_2f6d7
+	dbw $07, Func_2f6ce
+	dbw $09, Func_2f6e7
+	dbw $0b, Func_2f6ed
+	dbw $01, Func_2f6a0
+	dbw $10, Func_2f6b2
+	db $ff
+
+Func_2f6a0:
+	ld a, $0e
+	farcall GetEventValue
+	jr nz, .asm_2f6af
+	ld a, $14
+	ld [wd58e], a
+	jr .asm_2f6af
+.asm_2f6af
+	scf
+	ccf
+	ret
+
+Func_2f6b2:
+	ld a, $25
+	farcall GetVarValue
+	cp $09
+	jr z, .asm_2f6be
+	scf
+	ret
+.asm_2f6be
+	ld a, $10
+	farcall PlayAfterCurrentSong
+	scf
+	ccf
+	ret
+
+Func_2f6c7:
+	ld hl, $7601
+	call Func_324d
+	ret
+
+Func_2f6ce:
+	ld hl, $7614
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2f6d7:
+	ld hl, $7639
+	call Func_328c
+	jr nc, .asm_2f6e5
+	ld hl, $764a
+	call Func_32bf
+.asm_2f6e5
+	scf
+	ret
+
+Func_2f6e7:
+	farcall Func_3c3ca
+	scf
+	ret
+
+Func_2f6ed:
+	ld a, $03
+	farcall GetEventValue
+	jr z, .asm_2f707
+	ld a, $05
+	farcall Func_10da3
+	ld a, $03
+	farcall ZeroOutEventValue
+	ld a, [wd58e]
+	ld [wCurMusic], a
+.asm_2f707
+	scf
+	ret
+
+SECTION "Bank b@77ca", ROMX[$77ca], BANK[$b]
+
+Data_2f7ca:
+	db MAP_FIRE_CLUB
+	dba Data_2f83b
+	db $0e
+
+SECTION "Bank b@783b", ROMX[$783b], BANK[$b]
+Data_2f83b:
+	dbw $06, Func_2f85e
+	dbw $08, Func_2f8c8
+	dbw $09, Func_2f8d8
+	dbw $02, Func_2f86e
+	dbw $07, Func_2f865
+	dbw $01, Func_2f84e
+	db $ff
+
+Func_2f84e:
+	ld a, $0e
+	farcall GetEventValue
+	jr nz, .asm_2f85b
+	ld a, $14
+	ld [wd58e], a
+.asm_2f85b
+	scf
+	ccf
+	ret
+
+Func_2f85e:
+	ld hl, $77cf
+	call Func_324d
+	ret
+
+Func_2f865:
+	ld hl, $77e2
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2f86e:
+; TODO: this function doesn't want to disasm
+
+
+SECTION "Bank b@78c8", ROMX[$78c8], BANK[$b]
+Func_2f8c8:
+	ld hl, $7801
+	call Func_328c
+	jr nc, .asm_2f8d6
+	ld hl, $7816
+	call Func_32bf
+.asm_2f8d6
+	scf
+	ret
+
+Func_2f8d8:
+	ld hl, $78e3
+	ld a, [$d60e]
+	call Func_344c
+	scf
+	ret
+; 0x2f8e3
+
+
+SECTION "Bank b@7cd5", ROMX[$7cd5], BANK[$b]
+
+Data_2fcd5:
+	db MAP_POKEMON_DOME_ENTRANCE
+	dba Data_2fd66
+	db $09
+
+SECTION "Bank b@7d66", ROMX[$7d66], BANK[$b]
+Data_2fd66:
+	dbw $06, Func_2fd83
+	dbw $08, Func_2fd93
+	dbw $07, Func_2fd8a
+	dbw $01, Func_2fd73
+	db $ff
+
+Func_2fd73:
+	ld a, $0b
+	farcall GetEventValue
+	jr nz, .asm_2fd80
+	ld a, $14
+	ld [wd58e], a
+.asm_2fd80
+	scf
+	ccf
+	ret
+
+Func_2fd83:
+	ld hl, $7cda
+	call Func_324d
+	ret
+
+Func_2fd8a:
+	ld hl, $7cff
+	call Func_3205
+	scf
+	ccf
+	ret
+
+Func_2fd93:
+	ld hl, $7d06
+	call Func_328c
+	jr nc, .asm_2fda1
+	ld hl, $7d0b
+	call Func_32bf
+.asm_2fda1
+	scf
+	ret
+; 0x2fda3
+
+
+SECTION "Bank b@7e45", ROMX[$7e45], BANK[$b]
+
+Data_2fe45:
+	db MAP_OVERHEAD_ISLANDS
+	dba Data_2fe4a
+	db $1e
+
+Data_2fe4a:
+	dbw $02, Func_2fe54
+	dbw $04, Func_2fe94
+	dbw $0f, Func_2fe97
+	db $ff
+
+Func_2fe54:
+	farcall InitOWObjects
+	ld a, [wd584]
+	cp $00
+	jr nz, .asm_2fe6c
+	ld a, $d1
+	ld de, $1080
+	ld b, $01
+	farcall LoadOWObject
+	jr .asm_2fe77
+.asm_2fe6c
+	ld a, $d1
+	ld de, $9010
+	ld b, $03
+	farcall LoadOWObject
+.asm_2fe77
+	ld a, $0a
+	ld [wd582], a
+	ld a, $0b
+	ld [wd592], a
+	ld hl, $7e9a
+	ld a, l
+	ld [wd593], a
+	ld a, h
+	ld [$d594], a
+	ld a, $00
+	call Func_338f
+	scf
+	ccf
+	ret
+
+Func_2fe94:
+	scf
+	ccf
+	ret
+
+Func_2fe97:
+	scf
+	ccf
+	ret
+; 0x2fe9a

--- a/src/engine/bank0c.asm
+++ b/src/engine/bank0c.asm
@@ -3,7 +3,7 @@ SECTION "Bank c@4080", ROMX[$4080], BANK[$c]
 Data_30080:
 	db OVERWORLD_MAP_GR
 	dba Data_30085
-	db $15
+	db MUSIC_GROVERWORLD
 
 Data_30085:
 	dbw $01, Func_30092

--- a/src/engine/bank0c.asm
+++ b/src/engine/bank0c.asm
@@ -22,8 +22,8 @@ Func_30092:
 	ccf
 	ret
 .asm_300a0
-	ld a, $1e
-	ld [wd58e], a
+	ld a, MUSIC_GRBLIMP
+	ld [wNextMusic], a
 	scf
 	ccf
 	ret

--- a/src/engine/bank0d.asm
+++ b/src/engine/bank0d.asm
@@ -1,0 +1,7 @@
+SECTION "Bank d@41c4", ROMX[$41c4], BANK[$d]
+
+ ; TODO: function left stubbed out because the disasm script has problems
+ ; this function disassembles incorrectly after the insctruction db $dd
+ ; if you run the script at 341c4. running at 341cd will give the 
+ ; correct output for the chunk after db $dd
+Func_341c4:

--- a/src/engine/bank0d.asm
+++ b/src/engine/bank0d.asm
@@ -1,7 +1,41 @@
 SECTION "Bank d@41c4", ROMX[$41c4], BANK[$d]
 
- ; TODO: function left stubbed out because the disasm script has problems
- ; this function disassembles incorrectly after the insctruction db $dd
- ; if you run the script at 341c4. running at 341cd will give the 
- ; correct output for the chunk after db $dd
 Func_341c4:
+	xor a
+	call Func_33f2
+	; Event Script @ 0x341c8
+	db $01
+	db $10
+	db $f1
+	db $09
+	db $dd
+	db $41
+	db $05
+	db $6e
+	db $12
+	db $33
+	db $98
+	db $01
+	db $1b
+	db $98
+	db $01
+	db $05
+	db $6f
+	db $12
+	db $08
+	db $e0
+	db $41
+	db $05
+	db $70
+	db $12
+	db $02
+	db $2d
+	db $f0
+	db $41
+	db $2f
+	db $16
+	db $03
+	db $00
+	ld a, [wNextMusic]
+	farcall PlayAfterCurrentSong
+	ret

--- a/src/engine/bank0d.asm
+++ b/src/engine/bank0d.asm
@@ -4,38 +4,10 @@ Func_341c4:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x341c8
-	db $01
-	db $10
-	db $f1
-	db $09
-	db $dd
-	db $41
-	db $05
-	db $6e
-	db $12
-	db $33
-	db $98
-	db $01
-	db $1b
-	db $98
-	db $01
-	db $05
-	db $6f
-	db $12
-	db $08
-	db $e0
-	db $41
-	db $05
-	db $70
-	db $12
-	db $02
-	db $2d
-	db $f0
-	db $41
-	db $2f
-	db $16
-	db $03
-	db $00
+	db $01, $10, $f1, $09, $dd, $41, $05, $6e, $12, $33
+	db $98, $01, $1b, $98, $01, $05, $6f, $12, $08, $e0
+	db $41, $05, $70, $12, $02, $2d, $f0, $41, $2f, $16
+	db $03, $00
 	ld a, [wNextMusic]
 	farcall PlayAfterCurrentSong
 	ret

--- a/src/engine/bank0f.asm
+++ b/src/engine/bank0f.asm
@@ -202,3 +202,12 @@ Prologue::
 	jr c, .loop_wait_2
 	ret
 ; 0x3c1b9
+
+SECTION "Bank f@43ca", ROMX[$43ca], BANK[$f]
+
+; TODO
+; something is weird about the way this function disassembles using
+; the python script. it tries to call Func_212, which I don't believe
+; is correct
+Func_3c3ca:
+	

--- a/src/engine/bank0f.asm
+++ b/src/engine/bank0f.asm
@@ -104,7 +104,7 @@ Prologue::
 	farcall SetOWObjectFrameset
 
 	ld a, OW_GR_BLIMP
-	farcall ClearOWObject
+	farcall _ClearOWObject
 
 	ld bc, TILEMAP_002
 	lb de, 0, 0
@@ -121,7 +121,7 @@ Prologue::
 	ld a, [wPlayerOWObject]
 	call WaitForOWObjectAnimation
 	ld a, [wPlayerOWObject]
-	farcall ClearOWObject
+	farcall _ClearOWObject
 	lb de, $44, $44
 	ld b, SOUTH
 	farcall LoadOWObject
@@ -180,7 +180,7 @@ Prologue::
 	farcall LoadOWObject
 	call WaitForOWObjectAnimation
 	ld a, OW_GR_BLIMP_BEAM
-	farcall ClearOWObject
+	farcall _ClearOWObject
 	ret
 
 .MovePlayer:

--- a/src/engine/bank0f.asm
+++ b/src/engine/bank0f.asm
@@ -160,7 +160,7 @@ Prologue::
 	pop bc
 	; override direction
 	ld a, OW_GR_BLIMP
-	farcall SetOWObjectDirection
+	farcall _SetOWObjectDirection
 	jr c, .loop
 	ret
 

--- a/src/engine/bank0f.asm
+++ b/src/engine/bank0f.asm
@@ -205,9 +205,116 @@ Prologue::
 
 SECTION "Bank f@43ca", ROMX[$43ca], BANK[$f]
 
-; TODO
-; something is weird about the way this function disassembles using
-; the python script. it tries to call Func_212, which I don't believe
-; is correct
 Func_3c3ca:
+	xor a
+	call Func_33f2
+	; Event Script @ 0x3c3ce
+	db $01
+	db $11
+	db $25
+	db $0f
+	db $10
+	db $f1
+	db $09
+	db $1b
+	db $44
+	db $13
+	db $22
+	db $12
+	db $22
+	db $0d
+	db $0a
+	db $0b
+	db $e3
+	db $43
+	db $11
+	db $22
+	db $0a
+	db $0d
+	db $03
+	db $0b
+	db $f8
+	db $43
+	db $09
+	db $ff
+	db $43
+	db $0d
+	db $06
+	db $09
+	db $06
+	db $44
+	db $0d
+	db $09
+	db $09
+	db $0d
+	db $44
+	db $08
+	db $14
+	db $44
+	db $50
+	db $41
+	db $44
+	db $00
+	db $08
+	db $1e
+	db $44
+	db $50
+	db $48
+	db $44
+	db $00
+	db $08
+	db $1e
+	db $44
+	db $50
+	db $52
+	db $44
+	db $00
+	db $08
+	db $1e
+	db $44
+	db $50
+	db $5c
+	db $44
+	db $00
+	db $08
+	db $1e
+	db $44
+	db $50
+	db $74
+	db $44
+	db $00
+	db $08
+	db $1e
+	db $44
+	db $05
+	db $cc
+	db $12
+	db $05
+	db $cd
+	db $12
+	db $02
+	db $36
+	db $0d
+	db $02
+	db $0a
+	db $2d
+	db $44
+	db $17
+	db $03
+	db $28
+	db $81
+	db $02
+	db $2d
+	db $92
+	db $44
+	db $2f
+	db $16
+	db $05
+	db $00
+	ld a, $00
+	ld [wd582], a
+	ld a, [wNextMusic]
+	farcall PlayAfterCurrentSong
+	ret
+; 0x3c441
 	

--- a/src/engine/bank0f.asm
+++ b/src/engine/bank0f.asm
@@ -209,108 +209,17 @@ Func_3c3ca:
 	xor a
 	call Func_33f2
 	; Event Script @ 0x3c3ce
-	db $01
-	db $11
-	db $25
-	db $0f
-	db $10
-	db $f1
-	db $09
-	db $1b
-	db $44
-	db $13
-	db $22
-	db $12
-	db $22
-	db $0d
-	db $0a
-	db $0b
-	db $e3
-	db $43
-	db $11
-	db $22
-	db $0a
-	db $0d
-	db $03
-	db $0b
-	db $f8
-	db $43
-	db $09
-	db $ff
-	db $43
-	db $0d
-	db $06
-	db $09
-	db $06
-	db $44
-	db $0d
-	db $09
-	db $09
-	db $0d
-	db $44
-	db $08
-	db $14
-	db $44
-	db $50
-	db $41
-	db $44
-	db $00
-	db $08
-	db $1e
-	db $44
-	db $50
-	db $48
-	db $44
-	db $00
-	db $08
-	db $1e
-	db $44
-	db $50
-	db $52
-	db $44
-	db $00
-	db $08
-	db $1e
-	db $44
-	db $50
-	db $5c
-	db $44
-	db $00
-	db $08
-	db $1e
-	db $44
-	db $50
-	db $74
-	db $44
-	db $00
-	db $08
-	db $1e
-	db $44
-	db $05
-	db $cc
-	db $12
-	db $05
-	db $cd
-	db $12
-	db $02
-	db $36
-	db $0d
-	db $02
-	db $0a
-	db $2d
-	db $44
-	db $17
-	db $03
-	db $28
-	db $81
-	db $02
-	db $2d
-	db $92
-	db $44
-	db $2f
-	db $16
-	db $05
-	db $00
+	db $01, $11, $25, $0f, $10, $f1, $09, $1b, $44, $13
+	db $22, $12, $22, $0d, $0a, $0b, $e3, $43, $11, $22
+	db $0a, $0d, $03, $0b, $f8, $43, $09, $ff, $43, $0d
+	db $06, $09, $06, $44, $0d, $09, $09, $0d, $44, $08
+	db $14, $44, $50, $41, $44, $00, $08, $1e, $44, $50
+	db $48, $44, $00, $08, $1e, $44, $50, $52, $44, $00
+	db $08, $1e, $44, $50, $5c, $44, $00, $08, $1e, $44
+	db $50, $74, $44, $00, $08, $1e, $44, $05, $cc, $12
+	db $05, $cd, $12, $02, $36, $0d, $02, $0a, $2d, $44
+	db $17, $03, $28, $81, $02, $2d, $92, $44, $2f, $16
+	db $05, $00
 	ld a, $00
 	ld [wd582], a
 	ld a, [wNextMusic]

--- a/src/engine/bank10.asm
+++ b/src/engine/bank10.asm
@@ -3,7 +3,7 @@ SECTION "Bank 10@4462", ROMX[$4462], BANK[$10]
 Data_40462:
 	db OVERWORLD_MAP_TCG
 	dba Data_40467
-	db $09
+	db MUSIC_OVERWORLD
 
 Data_40467:
 	dbw $01, Func_40474

--- a/src/engine/bank10.asm
+++ b/src/engine/bank10.asm
@@ -543,7 +543,7 @@ DoGRShipMovement:
 	farcall SetOWObjectTargetPosition
 	ld a, OW_GR_BLIMP
 	pop bc
-	farcall SetOWObjectDirection
+	farcall _SetOWObjectDirection
 
 ; does movement every 4 frames
 ; can be skipped with B button

--- a/src/engine/bank10.asm
+++ b/src/engine/bank10.asm
@@ -23,8 +23,8 @@ Func_40474:
 	ret
 
 .asm_40482
-	ld a, $1e
-	ld [wd58e], a
+	ld a, MUSIC_GRBLIMP
+	ld [wNextMusic], a
 	scf
 	ccf
 	ret

--- a/src/home/decompress.asm
+++ b/src/home/decompress.asm
@@ -138,7 +138,7 @@ DecompressData:
 	inc bc
 	ld [hli], a ; wDecompRepeatLengths
 	swap a
-.get_sequence_len
+.get_sequence_len::
 	and $f
 	inc a ; number of times to repeat
 	ld [hli], a ; wDecompNumBytesToRepeat

--- a/src/home/decompress.asm
+++ b/src/home/decompress.asm
@@ -138,7 +138,7 @@ DecompressData:
 	inc bc
 	ld [hli], a ; wDecompRepeatLengths
 	swap a
-.get_sequence_len::
+.get_sequence_len
 	and $f
 	inc a ; number of times to repeat
 	ld [hli], a ; wDecompNumBytesToRepeat

--- a/src/home/unsorted.asm
+++ b/src/home/unsorted.asm
@@ -379,7 +379,7 @@ Func_328c::
 	push af
 	call Func_3195
 	pop af
-	farcall SetOWObjectDirectionWrapper
+	farcall SetOWObjectDirection
 	pop hl
 	call Func_344c
 	ret

--- a/src/home/unsorted.asm
+++ b/src/home/unsorted.asm
@@ -379,7 +379,7 @@ Func_328c::
 	push af
 	call Func_3195
 	pop af
-	farcall Func_10dcf
+	farcall SetOWObjectDirectionWrapper
 	pop hl
 	call Func_344c
 	ret

--- a/src/layout.link
+++ b/src/layout.link
@@ -52,8 +52,12 @@ ROMX $09
 	"Bank 9"
 ROMX $0a
 	"Bank a"
+ROMX $0b
+	"Bank b"
 ROMX $0c
 	"Bank c"
+ROMX $0d
+	"Bank d"
 ROMX $0e
 	"Bank e"
 ROMX $0f

--- a/src/main.asm
+++ b/src/main.asm
@@ -40,9 +40,14 @@ INCLUDE "engine/gbc_only_disclaimer.asm"
 SECTION "Bank a", ROMX
 INCLUDE "engine/bank0a.asm"
 
+SECTION "Bank b", ROMX
+INCLUDE "engine/bank0b.asm"
+
 SECTION "Bank c", ROMX
 INCLUDE "engine/bank0c.asm"
 
+SECTION "Bank d", ROMX
+INCLUDE "engine/bank0d.asm"
 SECTION "Bank e", ROMX
 INCLUDE "engine/bank0e.asm"
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -48,6 +48,7 @@ INCLUDE "engine/bank0c.asm"
 
 SECTION "Bank d", ROMX
 INCLUDE "engine/bank0d.asm"
+
 SECTION "Bank e", ROMX
 INCLUDE "engine/bank0e.asm"
 

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -2232,7 +2232,10 @@ wd58b:: ; d58b
 wd58c:: ; d58c
 	ds $2
 
-wd58e:: ; d58e
+; MUSIC_* constant
+; See also: wCurMusic
+; notably passed to PlayAfterCurrentSong in bank03: Func_c175
+wNextMusic:: ; d58e
 	ds $1
 
 wd58f:: ; d58f
@@ -2367,6 +2370,8 @@ wd672:: ; d672
 wd673:: ; d673
 	ds $1
 
+; MUSIC_* constant
+; See also: wNextMusic
 wCurMusic:: ; d674
 	ds $1
 

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -2223,7 +2223,8 @@ wPlayerOWLocation:: ; d588
 wCurIsland:: ; d589
 	ds $1
 
-wd58a:: ; d58a
+; MAP_* constant
+wCurMap:: ; d58a
 	ds $1
 
 wd58b:: ; d58b


### PR DESCRIPTION
I disassembled a lot of data structures and functions in `bank0b` that are related to game maps by following the pointers in `bank03 - Data_c651`. There were 24 that pointed to bank0b, and I disassembled all of them. There are still dozens in the table that point to other banks, though. 

I filled in constants as best as I could, and named a few existing functions, VARs and RAM addresses that I figured out while working on this.

I'm not 100% sure how the functions in this data structure are used yet. There is one for every map, and many functions per map. Some (maybe all) of the functions seem to get called before the map loads, but I am not sure about the order in which they are called. I held off on trying to name most of the functions and data because of this.

### Things I need help with / feedback on

- I have never worked with game boy assembly before, and I ran into a few functions didn't disassemble correctly with tcg2disasm.py (the script hung forever). I left them stubbed out and marked them with TODOs.
- There are a lot of similar repeating data structures and functions. I'm not sure if there is a good way to refactor the data structure with a macro.