### PR TITLE
fix: incorrect handling of load-based opcodes when parse_data flag is set

### DIFF
--- a/tools/tcg2disasm.py
+++ b/tools/tcg2disasm.py
@@ -1419,7 +1419,7 @@ class Disassembler(object):
 						output_lines.pop(i)
 					elif label_name in line:
 					# if the label is used in a load-based opcode, replace it with the raw hex reference
-						output_lines[i] = output_lines[i].replace(label_name, "$%x" % get_local_address(label_addr))
+						output_lines[i] = output_lines[i].replace(label_name, "$%x" % label_addr)
 
 		# convert the modified list of lines into a string
 		output = "".join(output_lines)


### PR DESCRIPTION
Fixes incorrect handling of load-based opcodes when parse_data flag is set. I tested it out on a dozen functions or so while working on my other open PR.

Example output of a function before this fix:

Without -pd: (correct output, passes `make`):
```
Func_2ed3e:
	xor a
	call Func_33f2
	ld h, h
	ld [de], a
	nop
	call Func_2eda8
	jr c, .asm_2ed73
	or a
	jr nz, .asm_2ed58
	ld hl, $a2a <-------------------
	call LoadTxRam2
	ld hl, $40a4
	jr .asm_2ed61
.asm_2ed58
	ld a, $ee
	farcall ZeroOutEventValue
	ld hl, $451d
.asm_2ed61
	ld a, $0a
	ld [wd582], a
	ld a, $0d
	ld [wd592], a
	ld a, l
	ld [wd593], a
	ld a, h
	ld [$d594], a
.asm_2ed73
	scf
	ret
; 0x2ed75
```

With -pd (one bad byte, fails `make`):
```
Func_2ed3e:
	xor a
	call Func_33f2
	ld h, h
	ld [de], a
	nop
	call Func_2eda8
	jr c, .asm_2ed73
	or a
	jr nz, .asm_2ed58
	ld hl, $4a2a <-------------------
	call LoadTxRam2
	ld hl, $40a4
	jr .asm_2ed61
.asm_2ed58
	ld a, $ee
	farcall ZeroOutEventValue
	ld hl, $451d
.asm_2ed61
	ld a, $0a
	ld [wd582], a
	ld a, $0d
	ld [wd592], a
	ld a, l
	ld [wd593], a
	ld a, h
	ld [$d594], a
.asm_2ed73
	scf
	ret
; 0x2ed75
```
After this fix, -pd  on outputs the correct asm and passes `make`.

Originally in mentioned my comment on my other PR: https://github.com/pret/poketcg2/pull/26#issuecomment-3313962477