### PR TITLE
Name 141 WRAM variables

### DIFF
--- a/src/audio/music1.asm
+++ b/src/audio/music1.asm
@@ -74,7 +74,7 @@ Music1_PlaySFX:
 
 Music1_f404e:
 	call Music1_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music1_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music1_AssertSFXFinished:
 
 Music1_f4066:
 	call Music1_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music1_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music1_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music1_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music1_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music1_f4980
@@ -249,7 +249,7 @@ Music1_CheckForNewSound:
 	ret
 
 Music1_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music1_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music1_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music1_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music1_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music1_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music1_EmptyFunc:
@@ -440,17 +440,17 @@ Music1_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music1_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music1_UpdateChannel1:
 	call Music1_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music1_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music1_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music1_UpdateChannel2:
 	call Music1_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music1_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music1_UpdateChannel3:
 	call Music1_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music1_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music1_UpdateChannel4:
 	call Music1_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music1_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music1_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music1_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music1_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music1_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music1_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music1_PlayNextNote_pop:
 	jp Music1_PlayNextNote
 
 Music1_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music1_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music1_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music1_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music1_f4714:
 	ret
 
 Music1_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music1_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music1_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music1_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music1_f479c:
 	call Music1_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music1_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music1_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music1_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music1_LoadWaveInstrument:
 	ret
 
 Music1_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music1_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music1_f480a:
 	ret
 
 Music1_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music1_f485a:
 Music1_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music1_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music1_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music1_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music1_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music1_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music1_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music1_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music1_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music1_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music1_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music1_f4967:
 	ret
 
 Music1_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music1_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music1_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music1_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music1_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music1_BackupSong:
 	ld a, $4
 	call Music1_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music1_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music1_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music1_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music1_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music1_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music1_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music1_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music1_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music1_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music1_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music1_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music2.asm
+++ b/src/audio/music2.asm
@@ -74,7 +74,7 @@ Music2_PlaySFX:
 
 Music2_f404e:
 	call Music2_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music2_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music2_AssertSFXFinished:
 
 Music2_f4066:
 	call Music2_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music2_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music2_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music2_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music2_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music2_f4980
@@ -249,7 +249,7 @@ Music2_CheckForNewSound:
 	ret
 
 Music2_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music2_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music2_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music2_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music2_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music2_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music2_EmptyFunc:
@@ -440,17 +440,17 @@ Music2_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music2_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music2_UpdateChannel1:
 	call Music2_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music2_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music2_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music2_UpdateChannel2:
 	call Music2_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music2_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music2_UpdateChannel3:
 	call Music2_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music2_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music2_UpdateChannel4:
 	call Music2_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music2_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music2_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music2_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music2_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music2_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music2_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music2_PlayNextNote_pop:
 	jp Music2_PlayNextNote
 
 Music2_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music2_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music2_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music2_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music2_f4714:
 	ret
 
 Music2_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music2_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music2_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music2_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music2_f479c:
 	call Music2_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music2_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music2_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music2_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music2_LoadWaveInstrument:
 	ret
 
 Music2_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music2_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music2_f480a:
 	ret
 
 Music2_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music2_f485a:
 Music2_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music2_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music2_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music2_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music2_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music2_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music2_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music2_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music2_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music2_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music2_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music2_f4967:
 	ret
 
 Music2_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music2_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music2_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music2_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music2_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music2_BackupSong:
 	ld a, $4
 	call Music2_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music2_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music2_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music2_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music2_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music2_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music2_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music2_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music2_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music2_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music2_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music2_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music3.asm
+++ b/src/audio/music3.asm
@@ -74,7 +74,7 @@ Music3_PlaySFX:
 
 Music3_f404e:
 	call Music3_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music3_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music3_AssertSFXFinished:
 
 Music3_f4066:
 	call Music3_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music3_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music3_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music3_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music3_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music3_f4980
@@ -249,7 +249,7 @@ Music3_CheckForNewSound:
 	ret
 
 Music3_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music3_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music3_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music3_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music3_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music3_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music3_EmptyFunc:
@@ -440,17 +440,17 @@ Music3_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music3_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music3_UpdateChannel1:
 	call Music3_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music3_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music3_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music3_UpdateChannel2:
 	call Music3_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music3_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music3_UpdateChannel3:
 	call Music3_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music3_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music3_UpdateChannel4:
 	call Music3_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music3_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music3_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music3_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music3_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music3_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music3_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music3_PlayNextNote_pop:
 	jp Music3_PlayNextNote
 
 Music3_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music3_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music3_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music3_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music3_f4714:
 	ret
 
 Music3_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music3_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music3_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music3_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music3_f479c:
 	call Music3_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music3_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music3_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music3_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music3_LoadWaveInstrument:
 	ret
 
 Music3_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music3_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music3_f480a:
 	ret
 
 Music3_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music3_f485a:
 Music3_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music3_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music3_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music3_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music3_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music3_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music3_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music3_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music3_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music3_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music3_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music3_f4967:
 	ret
 
 Music3_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music3_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music3_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music3_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music3_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music3_BackupSong:
 	ld a, $4
 	call Music3_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music3_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music3_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music3_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music3_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music3_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music3_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music3_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music3_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music3_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music3_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music3_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music4.asm
+++ b/src/audio/music4.asm
@@ -74,7 +74,7 @@ Music4_PlaySFX:
 
 Music4_f404e:
 	call Music4_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music4_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music4_AssertSFXFinished:
 
 Music4_f4066:
 	call Music4_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music4_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music4_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music4_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music4_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music4_f4980
@@ -249,7 +249,7 @@ Music4_CheckForNewSound:
 	ret
 
 Music4_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music4_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music4_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music4_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music4_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music4_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music4_EmptyFunc:
@@ -440,17 +440,17 @@ Music4_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music4_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music4_UpdateChannel1:
 	call Music4_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music4_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music4_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music4_UpdateChannel2:
 	call Music4_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music4_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music4_UpdateChannel3:
 	call Music4_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music4_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music4_UpdateChannel4:
 	call Music4_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music4_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music4_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music4_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music4_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music4_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music4_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music4_PlayNextNote_pop:
 	jp Music4_PlayNextNote
 
 Music4_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music4_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music4_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music4_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music4_f4714:
 	ret
 
 Music4_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music4_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music4_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music4_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music4_f479c:
 	call Music4_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music4_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music4_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music4_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music4_LoadWaveInstrument:
 	ret
 
 Music4_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music4_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music4_f480a:
 	ret
 
 Music4_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music4_f485a:
 Music4_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music4_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music4_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music4_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music4_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music4_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music4_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music4_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music4_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music4_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music4_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music4_f4967:
 	ret
 
 Music4_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music4_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music4_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music4_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music4_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music4_BackupSong:
 	ld a, $4
 	call Music4_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music4_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music4_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music4_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music4_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music4_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music4_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music4_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music4_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music4_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music4_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music4_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music5.asm
+++ b/src/audio/music5.asm
@@ -74,7 +74,7 @@ Music5_PlaySFX:
 
 Music5_f404e:
 	call Music5_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music5_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music5_AssertSFXFinished:
 
 Music5_f4066:
 	call Music5_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music5_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music5_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music5_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music5_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music5_f4980
@@ -249,7 +249,7 @@ Music5_CheckForNewSound:
 	ret
 
 Music5_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music5_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music5_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music5_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music5_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music5_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music5_EmptyFunc:
@@ -440,17 +440,17 @@ Music5_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music5_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music5_UpdateChannel1:
 	call Music5_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music5_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music5_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music5_UpdateChannel2:
 	call Music5_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music5_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music5_UpdateChannel3:
 	call Music5_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music5_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music5_UpdateChannel4:
 	call Music5_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music5_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music5_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music5_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music5_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music5_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music5_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music5_PlayNextNote_pop:
 	jp Music5_PlayNextNote
 
 Music5_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music5_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music5_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music5_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music5_f4714:
 	ret
 
 Music5_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music5_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music5_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music5_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music5_f479c:
 	call Music5_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music5_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music5_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music5_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music5_LoadWaveInstrument:
 	ret
 
 Music5_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music5_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music5_f480a:
 	ret
 
 Music5_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music5_f485a:
 Music5_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music5_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music5_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music5_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music5_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music5_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music5_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music5_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music5_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music5_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music5_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music5_f4967:
 	ret
 
 Music5_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music5_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music5_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music5_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music5_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music5_BackupSong:
 	ld a, $4
 	call Music5_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music5_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music5_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music5_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music5_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music5_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music5_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music5_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music5_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music5_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music5_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music5_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music6.asm
+++ b/src/audio/music6.asm
@@ -74,7 +74,7 @@ Music6_PlaySFX:
 
 Music6_f404e:
 	call Music6_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music6_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music6_AssertSFXFinished:
 
 Music6_f4066:
 	call Music6_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music6_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music6_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music6_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music6_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music6_f4980
@@ -249,7 +249,7 @@ Music6_CheckForNewSound:
 	ret
 
 Music6_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music6_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music6_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music6_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music6_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music6_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music6_EmptyFunc:
@@ -440,17 +440,17 @@ Music6_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music6_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music6_UpdateChannel1:
 	call Music6_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music6_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music6_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music6_UpdateChannel2:
 	call Music6_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music6_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music6_UpdateChannel3:
 	call Music6_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music6_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music6_UpdateChannel4:
 	call Music6_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music6_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music6_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music6_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music6_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music6_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music6_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music6_PlayNextNote_pop:
 	jp Music6_PlayNextNote
 
 Music6_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music6_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music6_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music6_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music6_f4714:
 	ret
 
 Music6_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music6_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music6_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music6_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music6_f479c:
 	call Music6_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music6_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music6_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music6_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music6_LoadWaveInstrument:
 	ret
 
 Music6_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music6_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music6_f480a:
 	ret
 
 Music6_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music6_f485a:
 Music6_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music6_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music6_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music6_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music6_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music6_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music6_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music6_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music6_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music6_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music6_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music6_f4967:
 	ret
 
 Music6_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music6_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music6_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music6_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music6_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music6_BackupSong:
 	ld a, $4
 	call Music6_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music6_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music6_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music6_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music6_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music6_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music6_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music6_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music6_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music6_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music6_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music6_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/music7.asm
+++ b/src/audio/music7.asm
@@ -74,7 +74,7 @@ Music7_PlaySFX:
 
 Music7_f404e:
 	call Music7_LoadAudioWRAMBank
-	ld [wddf0], a
+	ld [wMusicChannelMuteMask], a
 	call Music7_UnloadAudioWRAMBank
 	ret
 
@@ -102,9 +102,9 @@ Music7_AssertSFXFinished:
 
 Music7_f4066:
 	call Music7_LoadAudioWRAMBank
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	xor $1
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	call Music7_UnloadAudioWRAMBank
 	ret
 
@@ -143,12 +143,12 @@ Music7_Init:
 	ld a, $77 ; set both speakers to max volume
 	ld [wMusicPanning], a
 	xor a
-	ld [wdd8c], a
-	ld [wde53], a
+	ld [wSFXChannelMask], a
+	ld [wSFXIsPlaying], a
 	ld [wMusicWaveChange], a
-	ld [wddef], a
-	ld [wddf0], a
-	ld [wddf2], a
+	ld [wMusicNoiseActive], a
+	ld [wMusicChannelMuteMask], a
+	ld [wMusicForceResetFlag], a
 	ld [wCurSfxID], a
 	ld [wAudio_d005], a
 	ld [wAudio_d011], a
@@ -163,7 +163,7 @@ Music7_Init:
 	ld hl, wMusicTie
 	add hl, bc
 	ld [hl], d
-	ld hl, wddb3
+	ld hl, wMusicChannelRestartFlag
 	add hl, bc
 	ld [hl], d
 	ld hl, wMusicPitchOffset
@@ -203,7 +203,7 @@ Music7_Update:
 	ld a, [wCurSongBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wddf2]
+	ld a, [wMusicForceResetFlag]
 	cp $0
 	jr z, .update_channels
 	call Music7_f4980
@@ -249,7 +249,7 @@ Music7_CheckForNewSound:
 	ret
 
 Music7_StopAllChannels:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	xor a
 	ld [wMusicIsPlaying], a
@@ -323,7 +323,7 @@ Music7_BeginSong:
 	ld [wMusicChannelPointers + 1], a
 	ld [wMusicMainLoopStart + 1], a
 	ld a, $1
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	ld [wMusicIsPlaying], a
 	xor a
 	ld [wMusicTie], a
@@ -353,7 +353,7 @@ Music7_BeginSong:
 	ld [wMusicChannelPointers + 3], a
 	ld [wMusicMainLoopStart + 3], a
 	ld a, $1
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	ld [wMusicIsPlaying + 1], a
 	xor a
 	ld [wMusicTie + 1], a
@@ -382,7 +382,7 @@ Music7_BeginSong:
 	ld [wMusicChannelPointers + 5], a
 	ld [wMusicMainLoopStart + 5], a
 	ld a, $1
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	ld [wMusicIsPlaying + 2], a
 	xor a
 	ld [wMusicTie + 2], a
@@ -411,7 +411,7 @@ Music7_BeginSong:
 	ld [wMusicChannelPointers + 7], a
 	ld [wMusicMainLoopStart + 7], a
 	ld a, $1
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	ld [wMusicIsPlaying + 3], a
 	xor a
 	ld [wMusicTie + 3], a
@@ -430,7 +430,7 @@ Music7_BeginSong:
 .no_channel_4
 	xor a
 	ld [wAudio_d011], a
-	ld [wddf2], a
+	ld [wMusicForceResetFlag], a
 	ret
 
 Music7_EmptyFunc:
@@ -440,17 +440,17 @@ Music7_UpdateChannel1:
 	ld a, [wMusicIsPlaying]
 	or a
 	jr z, .asm_f42fa
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f42d4
-	ld a, [wddc3]
+	ld a, [wMusicCutoffCountdown]
 	dec a
-	ld [wddc3], a
+	ld [wMusicCutoffCountdown], a
 	jr nz, .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	cp $1
 	jr z, .asm_f42d4
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f42d4
 	ld hl, rAUD1ENV
@@ -460,9 +460,9 @@ Music7_UpdateChannel1:
 	ld a, $80
 	ld [hl], a
 .asm_f42d4
-	ld a, [wddbb]
+	ld a, [wMusicNoteDuration]
 	dec a
-	ld [wddbb], a
+	ld [wMusicNoteDuration], a
 	jr nz, .asm_f42f4
 	ld a, [wMusicChannelPointers + 1]
 	ld h, a
@@ -479,7 +479,7 @@ Music7_UpdateChannel1:
 	call Music7_f485a
 	ret
 .asm_f42fa
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4309
 	ld a, AUD1ENV_UP
@@ -496,17 +496,17 @@ Music7_UpdateChannel2:
 	ld a, [wMusicIsPlaying + 1]
 	or a
 	jr z, .asm_f435f
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f4339
-	ld a, [wddc3 + 1]
+	ld a, [wMusicCutoffCountdown + 1]
 	dec a
-	ld [wddc3 + 1], a
+	ld [wMusicCutoffCountdown + 1], a
 	jr nz, .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	cp $1
 	jr z, .asm_f4339
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f4339
 	ld hl, rAUD2ENV
@@ -516,9 +516,9 @@ Music7_UpdateChannel2:
 	ld a, $80
 	ld [hl], a
 .asm_f4339
-	ld a, [wddbb + 1]
+	ld a, [wMusicNoteDuration + 1]
 	dec a
-	ld [wddbb + 1], a
+	ld [wMusicNoteDuration + 1], a
 	jr nz, .asm_f4359
 	ld a, [wMusicChannelPointers + 3]
 	ld h, a
@@ -535,7 +535,7 @@ Music7_UpdateChannel2:
 	call Music7_f485a
 	ret
 .asm_f435f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f436e
 	ld a, AUD2ENV_UP
@@ -549,25 +549,25 @@ Music7_UpdateChannel3:
 	ld a, [wMusicIsPlaying + 2]
 	or a
 	jr z, .asm_f43be
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f4398
-	ld a, [wddc3 + 2]
+	ld a, [wMusicCutoffCountdown + 2]
 	dec a
-	ld [wddc3 + 2], a
+	ld [wMusicCutoffCountdown + 2], a
 	jr nz, .asm_f4398
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	cp $1
 	jr z, .asm_f4398
 	ld a, [wMusicEcho + 2]
 	ldh [rAUD3LEVEL], a
 .asm_f4398
-	ld a, [wddbb + 2]
+	ld a, [wMusicNoteDuration + 2]
 	dec a
-	ld [wddbb + 2], a
+	ld [wMusicNoteDuration + 2], a
 	jr nz, .asm_f43b8
 	ld a, [wMusicChannelPointers + 5]
 	ld h, a
@@ -584,7 +584,7 @@ Music7_UpdateChannel3:
 	call Music7_f485a
 	ret
 .asm_f43be
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f43cd
 	ld a, $0
@@ -598,9 +598,9 @@ Music7_UpdateChannel4:
 	ld a, [wMusicIsPlaying + 3]
 	or a
 	jr z, .asm_f4400
-	ld a, [wddbb + 3]
+	ld a, [wMusicNoteDuration + 3]
 	dec a
-	ld [wddbb + 3], a
+	ld [wMusicNoteDuration + 3], a
 	jr nz, .asm_f43f6
 	ld a, [wMusicChannelPointers + 7]
 	ld h, a
@@ -614,17 +614,17 @@ Music7_UpdateChannel4:
 	call Music7_f480a
 	jr .asm_f4413
 .asm_f43f6
-	ld a, [wddef]
+	ld a, [wMusicNoiseActive]
 	or a
 	jr z, .asm_f4413
 	call Music7_f4839
 	ret
 .asm_f4400
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4413
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld a, AUD4ENV_UP
 	ldh [rAUD4ENV], a
 	swap a ; AUD4GO_RESTART
@@ -713,10 +713,10 @@ Music7_note:
 	jr z, .asm_f44b0
 	ld [hl], $1
 	xor a
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], a
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	ld [hl], a
 	inc [hl]
@@ -747,7 +747,7 @@ Music7_note:
 	add e
 	jr .asm_f44c1
 .asm_f44c7
-	ld hl, wddbb
+	ld hl, wMusicNoteDuration
 	add hl, bc
 	ld [hl], a
 	pop de
@@ -783,12 +783,12 @@ Music7_note:
 	pop bc
 	pop hl
 .asm_f44fb
-	ld hl, wddc3
+	ld hl, wMusicCutoffCountdown
 	add hl, bc
 	ld [hl], a
 	pop af
 	and $f0
-	ld hl, wddb7
+	ld hl, wMusicCh1CutoffEnable
 	add hl, bc
 	ld [hl], a
 	or a
@@ -833,7 +833,7 @@ Music7_note:
 	and $77
 	or d
 	ld [wMusicStereoPanning], a
-	ld de, wddab
+	ld de, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -853,11 +853,11 @@ Music7_note:
 	ld b, $0
 	ld a, l
 	ld d, h
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld [hli], a
 	ld [hl], d
 	ld a, $1
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f458e
 .asm_f4564
 	ld hl, wMusicCh1CurPitch
@@ -1382,7 +1382,7 @@ Music7_PlayNextNote_pop:
 	jp Music7_PlayNextNote
 
 Music7_f4714:
-	ld a, [wddb7]
+	ld a, [wMusicCh1CutoffEnable]
 	cp $0
 	jr z, .asm_f474a
 	ld d, $0
@@ -1404,7 +1404,7 @@ Music7_f4714:
 	jr z, .asm_1dc8b5
 	ld d, e
 .asm_1dc8b5
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, d
@@ -1413,7 +1413,7 @@ Music7_f4714:
 .asm_f4733
 	ld hl, wMusicTie
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld a, [wAudio_d083]
@@ -1430,7 +1430,7 @@ Music7_f4714:
 .asm_f474a
 	ld hl, wMusicTie
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_f4749
 	ld hl, rAUD1ENV
@@ -1442,7 +1442,7 @@ Music7_f4714:
 	ret
 
 Music7_f475a:
-	ld a, [wddb8]
+	ld a, [wMusicCh2CutoffEnable]
 	cp $0
 	jr z, .asm_f478c
 	ld d, $0
@@ -1464,7 +1464,7 @@ Music7_f475a:
 	jr z, .asm_1dc924
 	ld d, e
 .asm_1dc924
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, d
@@ -1473,7 +1473,7 @@ Music7_f475a:
 .asm_f4779
 	ld hl, wMusicTie + 1
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld a, [wMusicDuty2]
@@ -1488,7 +1488,7 @@ Music7_f475a:
 .asm_f478c
 	ld hl, wMusicTie + 1
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .asm_f478b
 	ld hl, rAUD2ENV
@@ -1509,7 +1509,7 @@ Music7_f479c:
 	call Music7_LoadWaveInstrument
 	ld d, $80
 .no_wave_change
-	ld a, [wddb9]
+	ld a, [wMusicCh3CutoffEnable]
 	cp $0
 	jr z, .asm_f47e1
 	ld hl, wMusicTie + 2
@@ -1530,7 +1530,7 @@ Music7_f479c:
 	jr z, .asm_1dc99c
 	ld d, e
 .asm_1dc99c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	ld a, d
@@ -1541,7 +1541,7 @@ Music7_f479c:
 .asm_f47cc
 	ld hl, wMusicTie + 2
 	ld [hl], $2
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1558,7 +1558,7 @@ Music7_f479c:
 .asm_f47e1
 	ld hl, wMusicTie + 2
 	ld [hl], $0
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .asm_f47e0
 	xor a
@@ -1590,14 +1590,14 @@ Music7_LoadWaveInstrument:
 	ret
 
 Music7_f480a:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr nz, .asm_f4829
-	ld a, [wddba]
+	ld a, [wMusicCh4CutoffEnable]
 	cp $0
 	jr z, .asm_f482a
 	ld de, rAUD4LEN
-	ld hl, wddab
+	ld hl, wMusicNoiseLenBuffer
 	ld a, [hli]
 	ld [de], a
 	inc e
@@ -1613,7 +1613,7 @@ Music7_f480a:
 	ret
 .asm_f482a
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	ld hl, rAUD4ENV
 	ld a, AUD4ENV_UP
 	ld [hli], a
@@ -1623,14 +1623,14 @@ Music7_f480a:
 	ret
 
 Music7_f4839:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 3, a
 	jr z, .asm_f4846
 	xor a
-	ld [wddef], a
+	ld [wMusicNoiseActive], a
 	jr .asm_f4859
 .asm_f4846
-	ld hl, wdded
+	ld hl, wMusicNoiseCurDataPtr
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -1659,12 +1659,12 @@ Music7_f485a:
 Music7_f4866:
 	ld a, [wMusicPanning]
 	ldh [rAUDVOL], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	ld hl, wMusicStereoPanning
 	ld a, [hli]
 	jr z, .asm_f4888
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and $f
 	ld d, a
 	swap d
@@ -1680,7 +1680,7 @@ Music7_f4866:
 	or d
 .asm_f4888
 	ld d, a
-	ld a, [wddf0]
+	ld a, [wMusicChannelMuteMask]
 	xor $ff
 	and $f
 	ld e, a
@@ -1696,7 +1696,7 @@ Music7_UpdateVibrato:
 	ld a, [hl]
 	cp $0
 	jr z, .asm_f4902
-	ld hl, wdde3
+	ld hl, wMusicVibratoCounter
 	add hl, bc
 	cp [hl]
 	jr z, .asm_f48ab
@@ -1714,7 +1714,7 @@ Music7_UpdateVibrato:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld d, $0
 	ld e, [hl]
@@ -1757,7 +1757,7 @@ Music7_UpdateVibrato:
 	ret
 .asm_f48ee
 	push hl
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	ld [hl], $0
 	pop hl
@@ -1781,7 +1781,7 @@ Music7_1dcaff:
 	ld a, c
 	cp $0
 	jr nz, .asm_1dcb12
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD1LEN
@@ -1791,14 +1791,14 @@ Music7_1dcaff:
 .asm_1dcb12
 	cp $1
 	jr nz, .asm_1dcb22
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .asm_1dcb22
 	ld de, rAUD2LEN
 	ld a, [hli]
 	ld [de], a
 .asm_1dcb22
-	ld hl, wdddb
+	ld hl, wMusicVibratoPhase
 	add hl, bc
 	inc [hl]
 	jp Music7_UpdateVibrato.asm_f48ab
@@ -1809,7 +1809,7 @@ Music7_f490b:
 	ld a, [wMusicVibratoDelay]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 0, a
 	jr nz, .done
 	ld a, e
@@ -1827,7 +1827,7 @@ Music7_f490b:
 	ld a, [wMusicVibratoDelay + 1]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 1, a
 	jr nz, .done
 	ld a, e
@@ -1844,7 +1844,7 @@ Music7_f490b:
 	ld a, [wMusicVibratoDelay + 2]
 	cp $0
 	jr z, .done
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	bit 2, a
 	jr nz, .done
 	ld a, e
@@ -1880,7 +1880,7 @@ Music7_f4967:
 	ret
 
 Music7_f4980:
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld d, a
 	bit 0, d
 	jr nz, .asm_f4990
@@ -1977,32 +1977,32 @@ Music7_BackupSong:
 	ld de, wMusicMainLoopStartBackup
 	ld a, $8
 	call Music7_CopyData
-	ld a, [wddab]
-	ld [wde76], a
-	ld a, [wddac]
-	ld [wde77], a
+	ld a, [wMusicNoiseLenBuffer]
+	ld [wMusicNoiseLenBufferBackup], a
+	ld a, [wMusicNoiseEnvBuffer]
+	ld [wMusicNoiseEnvBufferBackup], a
 	ld hl, wMusicOctave
 	ld de, wMusicOctaveBackup
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wddb3
-	ld de, wde7c
+	ld hl, wMusicChannelRestartFlag
+	ld de, wMusicChannelRestartFlagBackup
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wddb7
-	ld de, wde80
+	ld hl, wMusicCh1CutoffEnable
+	ld de, wMusicCutoffEnableBackup
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wddbb
-	ld de, wde84
+	ld hl, wMusicNoteDuration
+	ld de, wMusicNoteDurationBackup
 	ld a, $4
 	call Music7_CopyData
 	ld hl, wMusicCutoff
 	ld de, wMusicCutoffBackup
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wddc3
-	ld de, wde8c
+	ld hl, wMusicCutoffCountdown
+	ld de, wMusicCutoffCountdownBackup
 	ld a, $4
 	call Music7_CopyData
 	ld hl, wMusicEcho
@@ -2026,10 +2026,10 @@ Music7_BackupSong:
 	ld a, $4
 	call Music7_CopyData
 	ld a, $0
-	ld [wdddb], a
-	ld [wdddb + 1], a
-	ld [wdddb + 2], a
-	ld [wdddb + 3], a
+	ld [wMusicVibratoPhase], a
+	ld [wMusicVibratoPhase + 1], a
+	ld [wMusicVibratoPhase + 2], a
+	ld [wMusicVibratoPhase + 3], a
 	ld hl, wMusicVolume
 	ld de, wMusicVolumeBackup
 	ld a, $3
@@ -2038,12 +2038,12 @@ Music7_BackupSong:
 	ld de, wMusicFrequencyOffsetBackup
 	ld a, $3
 	call Music7_CopyData
-	ld hl, wdded
-	ld de, wdeaa
+	ld hl, wMusicNoiseCurDataPtr
+	ld de, wMusicNoiseCurDataPtrBackup
 	ld a, $2
 	call Music7_CopyData
 	ld a, $0
-	ld [wdeac], a
+	ld [wMusicNoiseActiveBackup], a
 	ld hl, wMusicChannelStackPointers
 	ld de, wMusicChannelStackPointersBackup
 	ld a, $8
@@ -2109,32 +2109,32 @@ Music7_LoadBackup:
 	ld de, wMusicMainLoopStart
 	ld a, $8
 	call Music7_CopyData
-	ld a, [wde76]
-	ld [wddab], a
-	ld a, [wde77]
-	ld [wddac], a
+	ld a, [wMusicNoiseLenBufferBackup]
+	ld [wMusicNoiseLenBuffer], a
+	ld a, [wMusicNoiseEnvBufferBackup]
+	ld [wMusicNoiseEnvBuffer], a
 	ld hl, wMusicOctaveBackup
 	ld de, wMusicOctave
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wde7c
-	ld de, wddb3
+	ld hl, wMusicChannelRestartFlagBackup
+	ld de, wMusicChannelRestartFlag
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wde80
-	ld de, wddb7
+	ld hl, wMusicCutoffEnableBackup
+	ld de, wMusicCh1CutoffEnable
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wde84
-	ld de, wddbb
+	ld hl, wMusicNoteDurationBackup
+	ld de, wMusicNoteDuration
 	ld a, $4
 	call Music7_CopyData
 	ld hl, wMusicCutoffBackup
 	ld de, wMusicCutoff
 	ld a, $4
 	call Music7_CopyData
-	ld hl, wde8c
-	ld de, wddc3
+	ld hl, wMusicCutoffCountdownBackup
+	ld de, wMusicCutoffCountdown
 	ld a, $4
 	call Music7_CopyData
 	ld hl, wMusicEchoBackup
@@ -2165,12 +2165,12 @@ Music7_LoadBackup:
 	ld de, wMusicFrequencyOffset
 	ld a, $3
 	call Music7_CopyData
-	ld hl, wdeaa
-	ld de, wdded
+	ld hl, wMusicNoiseCurDataPtrBackup
+	ld de, wMusicNoiseCurDataPtr
 	ld a, $2
 	call Music7_CopyData
-	ld a, [wdeac]
-	ld [wddef], a
+	ld a, [wMusicNoiseActiveBackup]
+	ld [wMusicNoiseActive], a
 	ld hl, wMusicChannelStackPointersBackup
 	ld de, wMusicChannelStackPointers
 	ld a, $8

--- a/src/audio/sfx1.asm
+++ b/src/audio/sfx1.asm
@@ -15,12 +15,12 @@ SFX_Play:
 	add hl, bc
 	ld c, l
 	ld b, h
-	ld a, [wde53]
+	ld a, [wSFXIsPlaying]
 	or a
 	jr z, .asm_1f805a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f802e
 	ld a, AUD1SWEEP_DOWN
 	ldh [rAUD1SWEEP], a
@@ -28,23 +28,23 @@ SFX_Play:
 	swap a ; AUD1HIGH_RESTART
 	ldh [rAUD1HIGH], a
 .asm_1f802e
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f803f
 	ld a, AUD2ENV_UP
 	ldh [rAUD2ENV], a
 	swap a ; AUD2HIGH_RESTART
 	ldh [rAUD2HIGH], a
 .asm_1f803f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f804c
 	ld a, $0
 	ldh [rAUD3LEVEL], a
 .asm_1f804c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
 	jr nc, .asm_1f805a
 	ld a, AUD4ENV_UP
@@ -53,7 +53,7 @@ SFX_Play:
 	ldh [rAUD4GO], a
 .asm_1f805a
 	ld a, $1
-	ld [wde53], a
+	ld [wSFXIsPlaying], a
 	ld hl, SFXHeaderPointers1
 	add hl, bc
 	ld a, [hli]
@@ -62,15 +62,15 @@ SFX_Play:
 	ld a, [hli]
 	ld [wCurSfxBank], a
 	ld a, [hli]
-	ld [wdd8c], a
-	ld [wde54], a
-	ld de, wd0e3
+	ld [wSFXChannelMask], a
+	ld [wSFXChannelLoadMask], a
+	ld de, wSFXChannelPointers
 	ld c, $0
 	ld b, $0
 .asm_fc031
-	ld a, [wde54]
+	ld a, [wSFXChannelLoadMask]
 	rrca
-	ld [wde54], a
+	ld [wSFXChannelLoadMask], a
 	jr nc, .asm_fc050
 	ld a, [hli]
 	ld [de], a
@@ -85,10 +85,10 @@ SFX_Play:
 	ld a, AUD1SWEEP_DOWN
 	ldh [rAUD1SWEEP], a
 .asm_1f8091
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld [hl], $0
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld [hl], $1
 	pop hl
@@ -108,7 +108,7 @@ SFX_Update:
 	ld a, [wCurSfxBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	jr nz, .asm_fc063
 	call Func_fc26c
@@ -117,7 +117,7 @@ SFX_Update:
 	xor a
 	ld b, a
 	ld c, a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld [wAudio_d0ed], a
 .asm_fc06c
 	ld hl, wAudio_d0ed
@@ -125,7 +125,7 @@ SFX_Update:
 	rrca
 	ld [hl], a
 	jr nc, .asm_fc08d
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld a, [hl]
 	dec a
@@ -134,7 +134,7 @@ SFX_Update:
 	call Func_fc18d
 	jr .asm_fc08d
 .asm_fc082
-	ld hl, wd0e3
+	ld hl, wSFXChannelPointers
 	add hl, bc
 	add hl, bc
 	ld a, [hli]
@@ -194,7 +194,7 @@ SFX_frequency:
 	ld a, [hli]
 	ld e, a
 	push hl
-	ld hl, wde37
+	ld hl, wSFXChannelFrequency
 	add hl, bc
 	add hl, bc
 	push bc
@@ -212,7 +212,7 @@ SFX_frequency:
 	ld d, a
 .asm_fc0e9
 	pop bc
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld a, [hl]
 	ld [hl], $0
@@ -234,7 +234,7 @@ SFX_frequency:
 	ld [hl], d
 	pop de
 Func_fc105:
-	ld hl, wd0e3
+	ld hl, wSFXChannelPointers
 	add hl, bc
 	add hl, bc
 	ld [hl], e
@@ -243,7 +243,7 @@ Func_fc105:
 	ret
 
 SFX_envelope:
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld a, $80
 	ld [hl], a
@@ -277,7 +277,7 @@ SFX_duty:
 	jp Func_fc094
 
 SFX_loop:
-	ld hl, wde43
+	ld hl, wSFXChannelLoopPtr
 	add hl, bc
 	add hl, bc
 	pop de
@@ -286,7 +286,7 @@ SFX_loop:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld hl, wde3f
+	ld hl, wSFXChannelLoopCount
 	add hl, bc
 	ld [hl], a
 	ld l, e
@@ -294,13 +294,13 @@ SFX_loop:
 	jp Func_fc094
 
 SFX_endloop:
-	ld hl, wde3f
+	ld hl, wSFXChannelLoopCount
 	add hl, bc
 	ld a, [hl]
 	dec a
 	jr z, .asm_fc162
 	ld [hl], a
-	ld hl, wde43
+	ld hl, wSFXChannelLoopPtr
 	add hl, bc
 	add hl, bc
 	ld a, [hli]
@@ -313,7 +313,7 @@ SFX_endloop:
 	jp Func_fc094
 
 SFX_pitch_offset:
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld e, l
 	ld d, h
@@ -331,7 +331,7 @@ SFX_wait:
 .asm_fc17c
 	call Func_fc18d
 .asm_fc17f
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld e, l
 	ld d, h
@@ -343,12 +343,12 @@ SFX_wait:
 	jp Func_fc105
 
 Func_fc18d:
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld a, [hl]
 	or a
 	jr z, .asm_fc1cc
-	ld hl, wde37
+	ld hl, wSFXChannelFrequency
 	add hl, bc
 	add hl, bc
 	bit 7, a
@@ -373,7 +373,7 @@ Func_fc18d:
 	adc b
 .asm_fc1b1
 	ld [hl], a
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld d, [hl]
 	ld [hl], $0
@@ -397,11 +397,11 @@ Func_fc18d:
 	ret
 
 Func_fc1cd:
-	ld hl, wde32
+	ld hl, wSFXNoisePitchOffset
 	ld a, [hl]
 	or a
 	jr z, .asm_fc201
-	ld hl, wde3d
+	ld hl, wSFXNoiseFrequency
 	bit 7, a
 	jr z, .asm_fc1e5
 	xor $ff
@@ -423,7 +423,7 @@ Func_fc1cd:
 	xor e
 	and $8
 	swap a
-	ld hl, wde2e
+	ld hl, wSFXNoiseRestartPending
 	ld e, [hl]
 	ld [hl], $0
 	or e
@@ -482,7 +482,7 @@ SFX_pan:
 	jr .asm_fc234
 .asm_fc23c
 	ld d, a
-	ld hl, wdd85
+	ld hl, wSFXStereoPanning
 	ld a, [hl]
 	and e
 	or d
@@ -506,9 +506,9 @@ SFX_end:
 	dec e
 	jr nz, .asm_fc24d
 	ld e, a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and e
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	ld a, c
 	rlca
 	rlca
@@ -527,7 +527,7 @@ SFX_end:
 
 Func_fc26c:
 	xor a
-	ld [wde53], a
+	ld [wSFXIsPlaying], a
 	ld [wSfxPriority], a
 	ld [wAudio_d005], a
 	ret

--- a/src/audio/sfx2.asm
+++ b/src/audio/sfx2.asm
@@ -15,12 +15,12 @@ SFX2_Play:
 	add hl, bc
 	ld c, l
 	ld b, h
-	ld a, [wde53]
+	ld a, [wSFXIsPlaying]
 	or a
 	jr z, .asm_1f805a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f802e
 	ld a, AUD1SWEEP_DOWN
 	ldh [rAUD1SWEEP], a
@@ -28,23 +28,23 @@ SFX2_Play:
 	swap a ; AUD1HIGH_RESTART
 	ldh [rAUD1HIGH], a
 .asm_1f802e
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f803f
 	ld a, AUD2ENV_UP
 	ldh [rAUD2ENV], a
 	swap a ; AUD2HIGH_RESTART
 	ldh [rAUD2HIGH], a
 .asm_1f803f
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	jr nc, .asm_1f804c
 	ld a, $0
 	ldh [rAUD3LEVEL], a
 .asm_1f804c
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	rrca
 	jr nc, .asm_1f805a
 	ld a, AUD4ENV_UP
@@ -53,7 +53,7 @@ SFX2_Play:
 	ldh [rAUD4GO], a
 .asm_1f805a
 	ld a, $1
-	ld [wde53], a
+	ld [wSFXIsPlaying], a
 	ld hl, SFXHeaderPointers2
 	add hl, bc
 	ld a, [hli]
@@ -62,15 +62,15 @@ SFX2_Play:
 	ld a, [hli]
 	ld [wCurSfxBank], a
 	ld a, [hli]
-	ld [wdd8c], a
-	ld [wde54], a
-	ld de, wd0e3
+	ld [wSFXChannelMask], a
+	ld [wSFXChannelLoadMask], a
+	ld de, wSFXChannelPointers
 	ld c, $0
 	ld b, $0
 .asm_fc031
-	ld a, [wde54]
+	ld a, [wSFXChannelLoadMask]
 	rrca
-	ld [wde54], a
+	ld [wSFXChannelLoadMask], a
 	jr nc, .asm_fc050
 	ld a, [hli]
 	ld [de], a
@@ -85,10 +85,10 @@ SFX2_Play:
 	ld a, AUD1SWEEP_DOWN
 	ldh [rAUD1SWEEP], a
 .asm_1f8091
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld [hl], $0
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld [hl], $1
 	pop hl
@@ -108,7 +108,7 @@ SFX2_Update:
 	ld a, [wCurSfxBank]
 	ldh [hBankROM], a
 	ld [rROMB], a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	or a
 	jr nz, .asm_fc063
 	call Func_fc26c_2
@@ -117,7 +117,7 @@ SFX2_Update:
 	xor a
 	ld b, a
 	ld c, a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	ld [wAudio_d0ed], a
 .asm_fc06c
 	ld hl, wAudio_d0ed
@@ -125,7 +125,7 @@ SFX2_Update:
 	rrca
 	ld [hl], a
 	jr nc, .asm_fc08d
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld a, [hl]
 	dec a
@@ -134,7 +134,7 @@ SFX2_Update:
 	call Func_fc18d_2
 	jr .asm_fc08d
 .asm_fc082
-	ld hl, wd0e3
+	ld hl, wSFXChannelPointers
 	add hl, bc
 	add hl, bc
 	ld a, [hli]
@@ -194,7 +194,7 @@ SFX2_frequency:
 	ld a, [hli]
 	ld e, a
 	push hl
-	ld hl, wde37
+	ld hl, wSFXChannelFrequency
 	add hl, bc
 	add hl, bc
 	push bc
@@ -212,7 +212,7 @@ SFX2_frequency:
 	ld d, a
 .asm_fc0e9
 	pop bc
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld a, [hl]
 	ld [hl], $0
@@ -234,7 +234,7 @@ SFX2_frequency:
 	ld [hl], d
 	pop de
 Func_fc105_2:
-	ld hl, wd0e3
+	ld hl, wSFXChannelPointers
 	add hl, bc
 	add hl, bc
 	ld [hl], e
@@ -243,7 +243,7 @@ Func_fc105_2:
 	ret
 
 SFX2_envelope:
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld a, $80
 	ld [hl], a
@@ -277,7 +277,7 @@ SFX2_duty:
 	jp Func_fc094_2
 
 SFX2_loop:
-	ld hl, wde43
+	ld hl, wSFXChannelLoopPtr
 	add hl, bc
 	add hl, bc
 	pop de
@@ -286,7 +286,7 @@ SFX2_loop:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld hl, wde3f
+	ld hl, wSFXChannelLoopCount
 	add hl, bc
 	ld [hl], a
 	ld l, e
@@ -294,13 +294,13 @@ SFX2_loop:
 	jp Func_fc094_2
 
 SFX2_endloop:
-	ld hl, wde3f
+	ld hl, wSFXChannelLoopCount
 	add hl, bc
 	ld a, [hl]
 	dec a
 	jr z, .asm_fc162
 	ld [hl], a
-	ld hl, wde43
+	ld hl, wSFXChannelLoopPtr
 	add hl, bc
 	add hl, bc
 	ld a, [hli]
@@ -313,7 +313,7 @@ SFX2_endloop:
 	jp Func_fc094_2
 
 SFX2_pitch_offset:
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld e, l
 	ld d, h
@@ -331,7 +331,7 @@ SFX2_wait:
 .asm_fc17c
 	call Func_fc18d_2
 .asm_fc17f
-	ld hl, wde33
+	ld hl, wSFXChannelFrameDelay
 	add hl, bc
 	ld e, l
 	ld d, h
@@ -343,12 +343,12 @@ SFX2_wait:
 	jp Func_fc105_2
 
 Func_fc18d_2:
-	ld hl, wde2f
+	ld hl, wSFXChannelPitchOffset
 	add hl, bc
 	ld a, [hl]
 	or a
 	jr z, .asm_fc1cc
-	ld hl, wde37
+	ld hl, wSFXChannelFrequency
 	add hl, bc
 	add hl, bc
 	bit 7, a
@@ -373,7 +373,7 @@ Func_fc18d_2:
 	adc b
 .asm_fc1b1
 	ld [hl], a
-	ld hl, wde2b
+	ld hl, wSFXChannelRestartPending
 	add hl, bc
 	ld d, [hl]
 	ld [hl], $0
@@ -397,11 +397,11 @@ Func_fc18d_2:
 	ret
 
 Func_fc1cd_2:
-	ld hl, wde32
+	ld hl, wSFXNoisePitchOffset
 	ld a, [hl]
 	or a
 	jr z, .asm_fc201
-	ld hl, wde3d
+	ld hl, wSFXNoiseFrequency
 	bit 7, a
 	jr z, .asm_fc1e5
 	xor $ff
@@ -423,7 +423,7 @@ Func_fc1cd_2:
 	xor e
 	and $8
 	swap a
-	ld hl, wde2e
+	ld hl, wSFXNoiseRestartPending
 	ld e, [hl]
 	ld [hl], $0
 	or e
@@ -482,7 +482,7 @@ SFX2_pan:
 	jr .asm_fc234
 .asm_fc23c
 	ld d, a
-	ld hl, wdd85
+	ld hl, wSFXStereoPanning
 	ld a, [hl]
 	and e
 	or d
@@ -506,9 +506,9 @@ SFX2_end:
 	dec e
 	jr nz, .asm_fc24d
 	ld e, a
-	ld a, [wdd8c]
+	ld a, [wSFXChannelMask]
 	and e
-	ld [wdd8c], a
+	ld [wSFXChannelMask], a
 	ld a, c
 	rlca
 	rlca
@@ -527,7 +527,7 @@ SFX2_end:
 
 Func_fc26c_2:
 	xor a
-	ld [wde53], a
+	ld [wSFXIsPlaying], a
 	ld [wSfxPriority], a
 	ld [wAudio_d005], a
 	ret

--- a/src/data/save.asm
+++ b/src/data/save.asm
@@ -20,7 +20,7 @@ WRAMToSRAMMapper_GeneralSave::
 	wram_sram_map wCurMusic,                                  1, $00, $ff
 	wram_sram_map wNextGameEvent,                             1, $00, $ff
 	wram_sram_map wNextWarpMap,                               1, $00, $ff
-	wram_sram_map wd54e,                                      2, $00, $ff
+	wram_sram_map wNextWarpPlayerCoords,                                      2, $00, $ff
 	wram_sram_map wPlayerOWObject,                            1, $00, $ff
 	wram_sram_map wCurMapScriptsBank,                         1, $00, $ff
 	wram_sram_map wCurMapScriptsPointer,                      2, $00, $ff
@@ -41,7 +41,7 @@ WRAMToSRAMMapper_GeneralSave::
 	wram_sram_map wEventVars,               EVENT_VAR_BYTES - 2, $00, $ff
 	wram_sram_map wGeneralVars,           GENERAL_VAR_BYTES - 2, $00, $ff
 	wram_sram_map wOWData,                                  177, $00, $ff
-	wram_sram_map wd98b,                 5 * MAX_NUM_OW_OBJECTS, $00, $ff
+	wram_sram_map wNPCStateBuffer,                 5 * MAX_NUM_OW_OBJECTS, $00, $ff
 	wram_sram_map wScrollTargetObject,                        1, $00, $ff
 	wram_sram_map wSelectedCoin,                              1, $00, $ff
 	wram_sram_map wCoinPage,                                  1, $00, $ff

--- a/src/engine/bank02.asm
+++ b/src/engine/bank02.asm
@@ -1,7 +1,7 @@
 _OpenDuelCheckMenu::
 	call ResetCheckMenuCursorPositionAndBlink
 	xor a
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 	call DrawWideTextBox
 ; reset cursor blink
 	xor a
@@ -52,7 +52,7 @@ DuelCheckMenu_YourPlayArea:
 	jr z, .no_here_comes_team_rocket
 	ld a, $02
 .no_here_comes_team_rocket
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 
 	ldh a, [hWhoseTurn]
 .draw
@@ -183,12 +183,12 @@ DuelCheckMenu_OppPlayArea:
 
 ; here comes team rocket on
 	ld a, $01
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 	jr .begin
 
 .default_1
 	ld a, %10000000
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 	jr .begin
 
 .clairvoyance_on_1
@@ -200,7 +200,7 @@ DuelCheckMenu_OppPlayArea:
 	ld a, $02
 
 .clairvoyance_on_here_comes_team_rocket_off_1
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 
 .begin
 	ldh a, [hWhoseTurn]
@@ -1337,7 +1337,7 @@ HandleCheckMenuInput_YourOrOppPlayArea:
 	ldh a, [hDPadHeld]
 	or a
 	jr z, .no_pad
-	ld a, [wd0cd]
+	ld a, [wCheckMenuCursorNavFlags]
 	and %10000000
 	ldh a, [hDPadHeld]
 	jr nz, .check_vertical
@@ -1349,7 +1349,7 @@ HandleCheckMenuInput_YourOrOppPlayArea:
 ; d = x, e = y
 
 .horizontal
-	ld a, [wd0cd]
+	ld a, [wCheckMenuCursorNavFlags]
 	and %01111111
 	cp $01
 	jr z, .incr_y_wrap
@@ -1392,7 +1392,7 @@ HandleCheckMenuInput_YourOrOppPlayArea:
 	jr z, .no_pad
 
 .vertical
-	ld a, [wd0cd]
+	ld a, [wCheckMenuCursorNavFlags]
 	and %01111111
 	cp $02
 	jr z, .toggle_y
@@ -1817,7 +1817,7 @@ HandleMultiDirectionalMenu:
 	inc hl
 	ld d, [hl]
 	ld a, [wMultiDirectionalMenuCursorPosition]
-	ld [wd0d0], a
+	ld [wPrevTransitionIndex], a
 	ld l, a
 	ld h, CURSOR_TRANSITION_STRUCT_LENGTH
 	call HtimesL
@@ -1879,7 +1879,7 @@ ENDR
 	ld a, [wDuelInitialPrizesUpperBitsSet]
 	and b
 	jr nz, .sfx
-	ld a, [wd0d0]
+	ld a, [wPrevTransitionIndex]
 	cp $06
 	jr nz, HandleMultiDirectionalMenu
 
@@ -1921,7 +1921,7 @@ ENDR
 
 .handled_cursor_pos
 	ld a, [wMultiDirectionalMenuCursorPosition]
-	ld [wd0d0], a
+	ld [wPrevTransitionIndex], a
 	ld b, $1
 	jr .make_bitmask_loop
 
@@ -3614,7 +3614,7 @@ HandleDeckBuildScreen:
 	ld [hl], d
 
 	ld a, $01
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .loop_input
 	call DoFrame
 	ldh a, [hDPadHeld]
@@ -3730,7 +3730,7 @@ HandleDeckConfigurationMenu:
 	call DoFrame
 	call HandleMultiDirectionalMenu
 	jr nc, .do_frame
-	ld [wd11d], a
+	ld [wDeckConfigMenuSelection], a
 	cp $ff
 	jr nz, .asm_9769
 .draw_icons
@@ -3777,7 +3777,7 @@ ConfirmDeckConfiguration:
 	call DrawHorizontalListCursor_Visible
 	ld a, [wCurCardTypeFilter]
 	call PrintFilteredCardList
-	ld a, [wd11d]
+	ld a, [wDeckConfigMenuSelection]
 	ld [wTempCardTypeFilter], a
 	ret
 
@@ -3832,7 +3832,7 @@ SaveDeckConfiguration:
 .go_back
 	call DrawCardTypeIconsAndPrintCardCounts
 	call PrintDeckBuildingCardList
-	ld a, [wd11d]
+	ld a, [wDeckConfigMenuSelection]
 	ld [wCurScrollMenuItem], a
 	ret
 
@@ -3864,7 +3864,7 @@ DismantleDeck:
 	call DrawHorizontalListCursor_Visible
 	call PrintDeckBuildingCardList
 	call EnableLCD
-	ld a, [wd11d]
+	ld a, [wDeckConfigMenuSelection]
 	ld [wCurScrollMenuItem], a
 	ret
 
@@ -5184,7 +5184,7 @@ HandleScrollListInput:
 	jr .asm_9ff4
 
 .asm_9fd8
-	ld a, [wd119]
+	ld a, [wCardListAllowLeftRight]
 	or a
 	jr z, .asm_9ff4
 	bit B_PAD_LEFT, b
@@ -5740,7 +5740,7 @@ HandleDeckConfirmationMenu:
 	ld [hl], d
 
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .loop_input
 	call DoFrame
 	call HandleScrollListInput
@@ -5755,7 +5755,7 @@ HandleDeckConfirmationMenu:
 	ld a, MENU_CONFIRM
 	call PlaySFXConfirmOrCancel
 	ld a, [wCurScrollMenuItem]
-	ld [wd11e], a
+	ld [wCardListScrollEntryBackup], a
 
 	; set wOwnedCardsCountList as current card list
 	; and show card page screen
@@ -6390,7 +6390,7 @@ HandleGiftCenterSendCardsMenu:
 	call DoFrame
 	call HandleMultiDirectionalMenu
 	jr nc, .loop_input
-	ld [wd11d], a
+	ld [wDeckConfigMenuSelection], a
 	cp $ff
 	jr nz, .confirm
 	call DrawCardTypeIconsAndPrintCardCounts
@@ -6489,7 +6489,7 @@ HandleBlackBoxSendCardsMenu:
 	call DoFrame
 	call HandleMultiDirectionalMenu
 	jr nc, .loop_input
-	ld [wd11d], a
+	ld [wDeckConfigMenuSelection], a
 	cp $ff
 	jr nz, .confirm
 	call DrawCardTypeIconsAndPrintCardCounts
@@ -6595,7 +6595,7 @@ HandlePlayersCardsScreen:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 
 .loop_input
 	call DoFrame
@@ -7840,7 +7840,7 @@ CardAlbum:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .loop_input
 	call DoFrame
 	farcall HandleScrollMenu
@@ -7907,7 +7907,7 @@ CardAlbum:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .loop
 	call DoFrame
 	call HandleScrollListInput
@@ -8310,7 +8310,7 @@ PrinterMenu_PokemonCards:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 
 .loop_frame_2
 	call DoFrame
@@ -8613,7 +8613,7 @@ _HandleDeckStatusCardList:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 
 .loop_input
 	call DoFrame
@@ -8630,7 +8630,7 @@ _HandleDeckStatusCardList:
 	ld a, MENU_CONFIRM
 	call PlaySFXConfirmOrCancel
 	ld a, [wTempCardTypeFilter]
-	ld [wd11e], a
+	ld [wCardListScrollEntryBackup], a
 	ld de, wUniqueDeckCardList
 	ld hl, wCurCardListPtr
 	ld [hl], e
@@ -8806,7 +8806,7 @@ GiftCenter_ReceiveCards:
 	ld [hl], d
 
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .loop_input
 	call DoFrame
 	call HandleScrollListInput
@@ -9080,9 +9080,9 @@ HandleGiftCenter::
 ; hl = text ID for text box
 DeckDiagnosisResult:
 	ld a, l
-	ld [wd394 + 0], a
+	ld [wDeckDiagnosisTextPtr + 0], a
 	ld a, h
-	ld [wd394 + 1], a
+	ld [wDeckDiagnosisTextPtr + 1], a
 
 	call GetSRAMPointerToCurDeck
 	call EnableSRAM
@@ -9115,7 +9115,7 @@ DeckDiagnosisResult:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 
 .loop_input
 	call DoFrame
@@ -9184,9 +9184,9 @@ DeckDiagnosisResult:
 	xor a
 	ld [wTxRam2 + 0], a
 	ld [wTxRam2 + 1], a
-	ld a, [wd394 + 0]
+	ld a, [wDeckDiagnosisTextPtr + 0]
 	ld l, a
-	ld a, [wd394 + 1]
+	ld a, [wDeckDiagnosisTextPtr + 1]
 	ld h, a
 	lb de, 1, 1
 	call PrintTextNoDelay_Init

--- a/src/engine/bank03.asm
+++ b/src/engine/bank03.asm
@@ -25,7 +25,7 @@ _CoreGameLoop::
 	dw StartMenu_ContinueDuel      ; STARTMENU_CONTINUE_DUEL
 
 StartMenu_NewGame:
-	ld hl, wd554
+	ld hl, wSaveDataFlags
 	bit 0, [hl]
 	jr z, .no_save_data
 	farcall AskToOverwriteSaveData
@@ -46,7 +46,7 @@ StartMenu_NewGame:
 	ret
 
 StartMenu_ContinueFromDiary:
-	ld hl, wd554
+	ld hl, wSaveDataFlags
 	bit 2, [hl]
 	jr z, .no_saved_duel
 	bit 1, [hl]
@@ -249,18 +249,18 @@ PauseMenu:
 
 HandleStartMenu:
 	xor a
-	ld [wd554], a
+	ld [wSaveDataFlags], a
 	call CheckIfHasBackupSave
 	jr c, .menu_config0
 	call ValidateBackupGeneralSaveData
 	jr c, .asm_c20f
 .asm_c1d7
-	ld hl, wd554
+	ld hl, wSaveDataFlags
 	set 0, [hl]
 	call LoadBackupSave
 	farcall CheckSavedDuelChecksum
 	jr c, .no_saved_duel
-	ld hl, wd554
+	ld hl, wSaveDataFlags
 	set 2, [hl]
 	; on second meeting, Ronald card pops with you
 	; and unlocks it in the start menu
@@ -272,7 +272,7 @@ HandleStartMenu:
 	jr c, .menu_config2
 	call ValidateGeneralSaveData
 	jr c, .menu_config2
-	ld hl, wd554
+	ld hl, wSaveDataFlags
 	set 1, [hl]
 	jr .menu_config3
 .no_saved_duel
@@ -337,8 +337,8 @@ Func_c24d:
 	xor a
 	ld [wNextGameEvent], a
 	ld [wNextWarpMap], a
-	ld [wd54e + 0], a
-	ld [wd54e + 1], a
+	ld [wNextWarpPlayerCoords + 0], a
+	ld [wNextWarpPlayerCoords + 1], a
 	ld [wCurMapScriptsBank], a
 	ld [wCurMapScriptsPointer + 0], a
 	ld [wCurMapScriptsPointer + 1], a
@@ -1340,15 +1340,15 @@ LoadMapHeader::
 ; a = NPC_* ID
 ; de = target position
 SetOWObjectTargetPosition:
-	ld [wd595], a
+	ld [wOWObjNPCID], a
 	push af
 	ld a, d
 	ld [wOWObjTargetX], a
 	ld a, e
 	ld [wOWObjTargetY], a
 	xor a
-	ld [wd59c], a
-	ld [wd59d], a
+	ld [wOWObjXSubPixel], a
+	ld [wOWObjYSubPixel], a
 	pop af
 	push de
 	farcall GetOWObjectPosition
@@ -1376,7 +1376,7 @@ SetOWObjectTargetPosition:
 ; x distance >= y distance
 	push bc
 	xor a
-	ld [wd598], a
+	ld [wOWObjXVelocityFract], a
 	ld a, 1
 	ld [wOWObjXVelocity], a
 	ld b, EAST
@@ -1387,7 +1387,7 @@ SetOWObjectTargetPosition:
 	ld [wOWObjXVelocity], a
 	ld b, WEST
 .got_x_dir
-	ld a, [wd595]
+	ld a, [wOWObjNPCID]
 	farcall _SetOWObjectDirection
 	ld a, 1
 	ld [wOWObjYVelocity], a
@@ -1418,7 +1418,7 @@ SetOWObjectTargetPosition:
 	; de = -de
 .positive_y_vel
 	ld a, e
-	ld [wd59a], a
+	ld [wOWObjYVelocityFract], a
 	ld a, d
 	ld [wOWObjYVelocity], a
 	jr .done
@@ -1427,7 +1427,7 @@ SetOWObjectTargetPosition:
 ; x distance < y distance
 	push bc
 	xor a
-	ld [wd59a], a
+	ld [wOWObjYVelocityFract], a
 	ld a, 1
 	ld [wOWObjYVelocity], a
 	ld b, SOUTH
@@ -1438,7 +1438,7 @@ SetOWObjectTargetPosition:
 	ld [wOWObjYVelocity], a
 	ld b, NORTH
 .got_y_dir
-	ld a, [wd595]
+	ld a, [wOWObjNPCID]
 	farcall _SetOWObjectDirection
 	ld a, 1
 	ld [wOWObjXVelocity], a
@@ -1468,7 +1468,7 @@ SetOWObjectTargetPosition:
 	; de = -de
 .positive_x_vel
 	ld a, e
-	ld [wd598], a
+	ld [wOWObjXVelocityFract], a
 	ld a, d
 	ld [wOWObjXVelocity], a
 .done
@@ -1476,7 +1476,7 @@ SetOWObjectTargetPosition:
 
 ; returns carry if still moving
 MoveOWObjectToTargetPosition:
-	ld a, [wd595]
+	ld a, [wOWObjNPCID]
 	farcall GetOWObjectPosition
 	ld a, [wOWObjTargetX]
 	cp d
@@ -1489,11 +1489,11 @@ MoveOWObjectToTargetPosition:
 	ret
 
 .change_x
-	ld a, [wd59c]
+	ld a, [wOWObjXSubPixel]
 	ld b, a
-	ld a, [wd598]
+	ld a, [wOWObjXVelocityFract]
 	add b
-	ld [wd59c], a
+	ld [wOWObjXSubPixel], a
 	ld a, [wOWObjXVelocity]
 	adc d
 	ld d, a
@@ -1501,16 +1501,16 @@ MoveOWObjectToTargetPosition:
 	ld a, [wOWObjTargetY]
 	cp e
 	jr z, .asm_d562
-	ld a, [wd59d]
+	ld a, [wOWObjYSubPixel]
 	ld b, a
-	ld a, [wd59a]
+	ld a, [wOWObjYVelocityFract]
 	add b
-	ld [wd59d], a
+	ld [wOWObjYSubPixel], a
 	ld a, [wOWObjYVelocity]
 	adc e
 	ld e, a
 .asm_d562
-	ld a, [wd595]
+	ld a, [wOWObjNPCID]
 	farcall SetOWObjectPosition
 	scf
 	ret
@@ -1522,8 +1522,8 @@ Func_d56b:
 	ld a, e
 	ld [wOWObjTargetY], a
 	xor a
-	ld [wd59c], a
-	ld [wd59d], a
+	ld [wOWObjXSubPixel], a
+	ld [wOWObjYSubPixel], a
 	ld a, [wOWScrollX]
 	ld b, a
 	ld a, [wOWScrollY]
@@ -1550,7 +1550,7 @@ Func_d56b:
 
 	push bc
 	xor a
-	ld [wd598], a
+	ld [wOWObjXVelocityFract], a
 	ld a, 1
 	ld [wOWObjXVelocity], a
 	ld a, [wOWScrollX]
@@ -1586,7 +1586,7 @@ Func_d56b:
 	ld d, a
 .asm_d5d8
 	ld a, e
-	ld [wd59a], a
+	ld [wOWObjYVelocityFract], a
 	ld a, d
 	ld [wOWObjYVelocity], a
 	jr .done
@@ -1594,7 +1594,7 @@ Func_d56b:
 .asm_d5e2
 	push bc
 	xor a
-	ld [wd59a], a
+	ld [wOWObjYVelocityFract], a
 	ld a, 1
 	ld [wOWObjYVelocity], a
 	ld a, [wOWScrollY]
@@ -1629,7 +1629,7 @@ Func_d56b:
 	ld d, a
 .asm_d621
 	ld a, e
-	ld [wd598], a
+	ld [wOWObjXVelocityFract], a
 	ld a, d
 	ld [wOWObjXVelocity], a
 .done
@@ -1651,11 +1651,11 @@ Func_d62a:
 	ret
 
 .asm_d641
-	ld a, [wd59c]
+	ld a, [wOWObjXSubPixel]
 	ld b, a
-	ld a, [wd598]
+	ld a, [wOWObjXVelocityFract]
 	add b
-	ld [wd59c], a
+	ld [wOWObjXSubPixel], a
 	ld a, [wOWObjXVelocity]
 	adc d
 	ld d, a
@@ -1663,11 +1663,11 @@ Func_d62a:
 	ld a, [wOWObjTargetY]
 	cp e
 	jr z, .asm_d667
-	ld a, [wd59d]
+	ld a, [wOWObjYSubPixel]
 	ld b, a
-	ld a, [wd59a]
+	ld a, [wOWObjYVelocityFract]
 	add b
-	ld [wd59d], a
+	ld [wOWObjYSubPixel], a
 	ld a, [wOWObjYVelocity]
 	adc e
 	ld e, a
@@ -2214,12 +2214,12 @@ GeneralVarMasks:
 	db $2c, %11111111 ; VAR_DUEL_START_THEME
 	db $33, %11111111 ; VAR_3E
 
-; clear 8 bytes from wd606
+; clear 8 bytes from wPkmnTypeBitfield
 ZeroOutBytes_wd606:
 	push af
 	push hl
 	xor a
-	ld hl, wd606
+	ld hl, wPkmnTypeBitfield
 REPT wD606_STRUCT_SIZE - 1
 	ld [hli], a
 ENDR
@@ -2228,13 +2228,13 @@ ENDR
 	pop af
 	ret
 
-; set n, [wd606 + m], where a = 8m + n
+; set n, [wPkmnTypeBitfield + m], where a = 8m + n
 SetBit_wd606:
 	push af
 	push bc
 	push hl
 	push af
-	ld hl, wd606
+	ld hl, wPkmnTypeBitfield
 REPT 3
 	srl a
 ENDR
@@ -2258,13 +2258,13 @@ ENDR
 	pop af
 	ret
 
-; res n, [wd606 + m], where a = 8m + n
+; res n, [wPkmnTypeBitfield + m], where a = 8m + n
 ClearBit_wd606:
 	push af
 	push bc
 	push hl
 	push af
-	ld hl, wd606
+	ld hl, wPkmnTypeBitfield
 REPT 3
 	srl a
 ENDR
@@ -2289,13 +2289,13 @@ ENDR
 	pop af
 	ret
 
-; bit n, [wd606 + m], where a = 8m + n
+; bit n, [wPkmnTypeBitfield + m], where a = 8m + n
 CheckBit_wd606:
 	push bc
 	push hl
 	push af
 	push af
-	ld hl, wd606
+	ld hl, wPkmnTypeBitfield
 REPT 3
 	srl a
 ENDR

--- a/src/engine/bank04.asm
+++ b/src/engine/bank04.asm
@@ -92,9 +92,9 @@ SetAllCoinsObtainedAndShowCoinMenu:
 	call SetSpriteAnimationAndFadePalsFrameFunc
 	farcall StartFadeToWhite
 	farcall WaitPalFading_Bank07
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	res 2, a
-	ld [wd693], a
+	ld [wGfxCacheFlags], a
 	call SetAllCoinEvents
 	farcall ShowCoinMenuWithoutIncomingCoin ; same menu that you see from the in-game coin menu
 	call UnsetSpriteAnimationAndFadePalsFrameFunc
@@ -399,21 +399,21 @@ Func_102ef:
 	call WriteBCBytesToHL
 
 	ld a, $80
-	ld hl, wd6d4
+	ld hl, wDecompressedTilemapPermissions
 	ld bc, $101
 	call WriteBCBytesToHL
 
 	xor a
-	ld [wd852], a
-	ld hl, wd853
+	ld [wOWTilemapOverlayCount], a
+	ld hl, wOWTilemapOverlayBuffer
 	ld bc, $40
 	call WriteBCBytesToHL
 
 	call Func_10327
 
 	xor a
-	ld [wd896 + 0], a
-	ld [wd896 + 1], a
+	ld [wPalAnimTarget + 0], a
+	ld [wPalAnimTarget + 1], a
 	pop hl
 	pop de
 	pop bc
@@ -603,7 +603,7 @@ SetOWScrollState:
 
 ; updates scrolling, depending on wOWScrollState:
 ; - if $0 then move to target position
-;   with wd7e8 = x and wd7e9 = y
+;   with wOWScrollTargetX = x and wOWScrollTargetY = y
 ; - if $1 then move scroll so that
 ;   wScrollTargetObject is at the center
 UpdateOWScroll::
@@ -649,7 +649,7 @@ UpdateOWScroll::
 	cp $40
 	ld a, 0
 	jr c, .got_x_scroll
-	ld a, [wd7dc]
+	ld a, [wLoadedBGMapWidth]
 REPT 3
 	sla a
 ENDR
@@ -667,7 +667,7 @@ ENDR
 	cp $40
 	ld a, 0
 	jr c, .got_y_scroll
-	ld a, [wd7dd]
+	ld a, [wLoadedBGMapHeight]
 REPT 3
 	sla a
 ENDR
@@ -683,7 +683,7 @@ ENDR
 	ret
 
 .MoveToTargetPosition:
-	ld a, [wd7e8]
+	ld a, [wOWScrollTargetX]
 	ld b, a
 	ld hl, wOWScrollX
 	ld a, [hl]
@@ -696,7 +696,7 @@ ENDR
 .incr_x_scroll
 	inc [hl]
 .no_x_scroll
-	ld a, [wd7e9]
+	ld a, [wOWScrollTargetY]
 	ld b, a
 	ld hl, wOWScrollY
 	ld a, [hl]
@@ -714,10 +714,10 @@ ENDR
 ; input: d = x_1, e = y_1
 ; x_2 = [wOWScrollX] * 8 if x_1 bit 7 is set, x_1 otherwise
 ; y_2 = [wOWScrollY] * 8 if x_1 bit 7 is set, y_1 otherwise
-; x_n = [wd7dc] * 8 - $a0, y_n = [wd7dd] * 8 - $90
+; x_n = [wLoadedBGMapWidth] * 8 - $a0, y_n = [wLoadedBGMapHeight] * 8 - $90
 ; output:
-; [wd7e8] = min(x_2 * 8, x_n),
-; [wd7e9] = min(y_2 * 8, y_n),
+; [wOWScrollTargetX] = min(x_2 * 8, x_n),
+; [wOWScrollTargetY] = min(y_2 * 8, y_n),
 ; [wOWScrollState] = 0
 Func_104ad:
 	push af
@@ -736,7 +736,7 @@ REPT 3
 	add a
 ENDR
 	ld c, a
-	ld a, [wd7dc]
+	ld a, [wLoadedBGMapWidth]
 REPT 3
 	add a
 ENDR
@@ -748,7 +748,7 @@ ENDR
 	ld a, b
 ; fallthrough
 .got_x
-	ld [wd7e8], a
+	ld [wOWScrollTargetX], a
 
 	ld a, e
 	bit 7, a
@@ -763,7 +763,7 @@ REPT 3
 	add a
 ENDR
 	ld c, a
-	ld a, [wd7dd]
+	ld a, [wLoadedBGMapHeight]
 REPT 3
 	add a
 ENDR
@@ -775,7 +775,7 @@ ENDR
 	ld a, b
 ; fallthrough
 .got_y
-	ld [wd7e9], a
+	ld [wOWScrollTargetY], a
 	xor a
 	call SetOWScrollState
 	pop de
@@ -814,7 +814,7 @@ ENDR
 	ret
 
 ; output:
-; a = 0 if [wOWScrollState] = 0 AND [wOWScrollX] = [wd7e8] AND [wOWScrollY] = [wd7e9]
+; a = 0 if [wOWScrollState] = 0 AND [wOWScrollX] = [wOWScrollTargetX] AND [wOWScrollY] = [wOWScrollTargetY]
 ; a = 1 otherwise
 CheckOWScroll:
 	push bc
@@ -824,12 +824,12 @@ CheckOWScroll:
 	jr nz, .got_result
 	ld a, [wOWScrollX]
 	ld b, a
-	ld a, [wd7e8]
+	ld a, [wOWScrollTargetX]
 	cp b
 	jr nz, .got_result
 	ld a, [wOWScrollY]
 	ld b, a
-	ld a, [wd7e9]
+	ld a, [wOWScrollTargetY]
 	cp b
 	jr nz, .got_result
 	ld c, 0
@@ -840,7 +840,7 @@ CheckOWScroll:
 	ret
 
 ; output:
-; a = [wd6d4 + (e/2)*16 + d/2]
+; a = [wDecompressedTilemapPermissions + (e/2)*16 + d/2]
 Func_10541:
 	push bc
 	push de
@@ -848,7 +848,7 @@ Func_10541:
 	srl d
 	srl e
 	ld b, 0
-	ld hl, wd6d4
+	ld hl, wDecompressedTilemapPermissions
 REPT 4
 	sla e
 ENDR
@@ -877,14 +877,14 @@ Func_1055e:
 	ld bc, $64
 	call WriteBCBytesToHL
 	call LoadOWAnimatedTiles
-	ld hl, wd852
+	ld hl, wOWTilemapOverlayCount
 	ld a, [hl]
 	and a
 	jr z, .asm_1059a
 	ld c, a
 	xor a
 	ld [hl], a
-	ld hl, wd853
+	ld hl, wOWTilemapOverlayBuffer
 .asm_10589
 	push bc
 	ld a, [hli]
@@ -984,19 +984,19 @@ Func_105de:
 
 ; input: a, b, c
 ; output:
-; [wd896] = c
-; [wd896 + 1] = b
-; [wd896 + 2] = [wd896 + 3] = a
-; [wd896 + 4] = 0
+; [wPalAnimTarget] = c
+; [wPalAnimTarget + 1] = b
+; [wPalAnimTarget + 2] = [wPalAnimTarget + 3] = a
+; [wPalAnimTarget + 4] = 0
 SetwD896:
-	ld [wd896 + 2], a
-	ld [wd896 + 3], a
+	ld [wPalAnimTarget + 2], a
+	ld [wPalAnimTarget + 3], a
 	ld a, c
-	ld [wd896], a
+	ld [wPalAnimTarget], a
 	ld a, b
-	ld [wd896 + 1], a
+	ld [wPalAnimTarget + 1], a
 	xor a
-	ld [wd896 + 4], a
+	ld [wPalAnimTarget + 4], a
 	ret
 
 CopyCGBBGPalsWithID_BeginWithPal2:
@@ -1160,9 +1160,9 @@ FillBoxInBGMap:
 	push de
 	push hl
 	ld a, h
-	ld [wd89d], a
+	ld [wBGBoxFillTile], a
 	ld a, l
-	ld [wd89e], a
+	ld [wBGBoxFillAttr], a
 	push bc
 	ld b, d
 	ld c, e
@@ -1176,14 +1176,14 @@ FillBoxInBGMap:
 	call BankswitchVRAM
 	di
 	call WaitForLCDOff
-	ld a, [wd89d]
+	ld a, [wBGBoxFillTile]
 	ld [hl], a
 	ei
 	ld a, BANK("VRAM1")
 	call BankswitchVRAM
 	di
 	call WaitForLCDOff
-	ld a, [wd89e]
+	ld a, [wBGBoxFillAttr]
 	ld [hli], a
 	ei
 	dec b
@@ -1452,11 +1452,11 @@ RestoreObjectPalsToDE:
 	ret
 
 SetwD8A1:
-	ld [wd8a1], a
+	ld [wOWNPCMovementMode], a
 	ret
 
 GetwD8A1::
-	ld a, [wd8a1]
+	ld a, [wOWNPCMovementMode]
 	ret
 
 ; flush c non-CGB object pals and a single CGB pal
@@ -1489,8 +1489,8 @@ ClearSpriteAnims:
 	xor a
 	ld [wCurVRAMTile], a
 	ld [wNumSpriteTilesets], a
-	ld [wd96f], a
-	ld [wd970], a
+	ld [wSpriteAnimRenderFlags], a
+	ld [wSpriteAnimCoordFlags], a
 	ld bc, NUM_SPRITE_ANIM_STRUCTS * SPRITEANIMSTRUCT_LENGTH
 	ld hl, wSpriteAnimationStructs
 	call WriteBCBytesToHL
@@ -1588,11 +1588,11 @@ SetNewSpriteAnimValues::
 	ret
 
 Func_10989:
-	ld [wd96f], a
+	ld [wSpriteAnimRenderFlags], a
 	ret
 
 Func_1098d:
-	ld [wd970], a
+	ld [wSpriteAnimCoordFlags], a
 	ret
 
 MoveSpriteAnim:
@@ -2714,10 +2714,10 @@ Func_10e3c::
 	push de
 	push hl
 	push bc
-	ld [wd989], a
+	ld [wNPCStepNPCID], a
 	xor a
-	ld [wd98a], a
-	ld a, [wd989]
+	ld [wNPCStepResult], a
+	ld a, [wNPCStepNPCID]
 	call GetOWObjectWithID
 	bit 5, [hl] ; OWOBJSTRUCT_FLAGS
 	jr z, .asm_10e8f
@@ -2749,7 +2749,7 @@ Func_10e3c::
 	dec d
 
 .got_direction
-	ld a, [wd986]
+	ld a, [wNPCBoundaryOverride]
 	cp $ff
 	jr z, .asm_10e7f
 	ld a, d
@@ -2769,12 +2769,12 @@ Func_10e3c::
 	jr nz, .blocked
 .asm_10e8f
 	ld a, $10
-	ld [wd98a], a
+	ld [wNPCStepResult], a
 .blocked
 	pop bc
-	ld a, [wd98a]
+	ld a, [wNPCStepResult]
 	ld e, a
-	ld a, [wd989]
+	ld a, [wNPCStepNPCID]
 	call Func_1132e
 	pop hl
 	pop de
@@ -2889,12 +2889,12 @@ SetOWObjectFrameset:
 
 FillwD986:
 	ld a, $ff
-	ld [wd986], a
+	ld [wNPCBoundaryOverride], a
 	ret
 
 ClearwD986:
 	ld a, 0
-	ld [wd986], a
+	ld [wNPCBoundaryOverride], a
 	ret
 
 Func_10f32:
@@ -2902,7 +2902,7 @@ Func_10f32:
 	push bc
 	push de
 	push hl
-	ld de, wd98b
+	ld de, wNPCStateBuffer
 	ld hl, wOWObjects
 	ld c, MAX_NUM_OW_OBJECTS
 .loop
@@ -2960,7 +2960,7 @@ Func_10f78:
 	push de
 	push hl
 	call Func_10d40
-	ld hl, wd98b
+	ld hl, wNPCStateBuffer
 	ld c, MAX_NUM_OW_OBJECTS
 .loop
 	ld a, [hl]
@@ -3671,7 +3671,7 @@ Func_1132e:
 	and $07
 	ld b, a
 	xor a
-	ld [wda8b], a
+	ld [wNPCStepAmount], a
 	ld a, c
 	and a
 	jr z, .done
@@ -3683,14 +3683,14 @@ Func_1132e:
 	ld a, e
 	and a
 	jr z, .done
-	ld [wda8b], a
+	ld [wNPCStepAmount], a
 	inc c
 	call SetSpriteAnimMotion
 .done
 	pop hl
 	pop de
 	pop bc
-	ld a, [wda8b]
+	ld a, [wNPCStepAmount]
 	ret
 
 ; a = NPC_* ID
@@ -3953,7 +3953,7 @@ TurnOnCurChipsHUD:
 	push bc
 	push de
 	push hl
-	ld a, [wda98]
+	ld a, [wChipCountWindowVisible]
 	and a
 	jr nz, .fill
 
@@ -3978,7 +3978,7 @@ TurnOnCurChipsHUD:
 
 .fill
 	ld a, $ff
-	ld [wda98], a
+	ld [wChipCountWindowVisible], a
 	pop hl
 	pop de
 	pop bc
@@ -3990,7 +3990,7 @@ TurnOffCurChipsHUD:
 	push bc
 	push de
 	push hl
-	ld a, [wda98]
+	ld a, [wChipCountWindowVisible]
 	and a
 	jr z, .clear
 
@@ -3999,7 +3999,7 @@ TurnOffCurChipsHUD:
 
 .clear
 	xor a
-	ld [wda98], a
+	ld [wChipCountWindowVisible], a
 	pop hl
 	pop de
 	pop bc
@@ -4028,7 +4028,7 @@ AddChips:
 	ld [wGameCenterChips], a
 	ld a, h
 	ld [wGameCenterChips + 1], a
-	ld a, [wda98]
+	ld a, [wChipCountWindowVisible]
 	and a
 	jr z, .done
 	call PrintNumberOfChips
@@ -4070,7 +4070,7 @@ SubtractChips:
 	ld [wGameCenterChips], a
 	ld a, h
 	ld [wGameCenterChips + 1], a
-	ld a, [wda98]
+	ld a, [wChipCountWindowVisible]
 	and a
 	jr z, .done
 	call PrintNumberOfChips
@@ -4080,7 +4080,7 @@ SubtractChips:
 	pop af
 	ret
 
-; clear wda98 to wda9c
+; clear wChipCountWindowVisible to wda9c
 ClearGameCenterChips:
 	push af
 	xor a
@@ -4088,7 +4088,7 @@ ClearGameCenterChips:
 	ld [wGameCenterChips + 1], a
 	ld [wGameCenterBankedChips], a
 	ld [wGameCenterBankedChips + 1], a
-	ld [wda98], a
+	ld [wChipCountWindowVisible], a
 	pop af
 	ret
 
@@ -4394,9 +4394,9 @@ LoadTitleScreenGraphics:
 	ld b, $04
 	ld c, $00
 	call LoadBGGraphics
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	set 3, a
-	ld [wd693], a
+	ld [wGfxCacheFlags], a
 	ret
 
 .data
@@ -4840,7 +4840,7 @@ AnimateSubtitleEnter:
 
 .Distort:
 	ld a, $0f
-	ld [wdafd], a
+	ld [wIntroDistortionCounter], a
 	xor a
 	ld [wIntroStateCounter], a
 	call .Func_11a98
@@ -4880,7 +4880,7 @@ AnimateSubtitleEnter:
 	; a = (rLY - $30 + wIntroStateCounter) ^ ((rLY & %1) << 4) & %11111
 	ld b, $00
 	ld c, a
-	ld hl, wdac1
+	ld hl, wIntroLineSCXBuffer
 	add hl, bc
 	call WaitForLCDOff
 	ld a, [hl]
@@ -4895,7 +4895,7 @@ AnimateSubtitleEnter:
 	inc a
 	ld [wIntroStateCounter], a
 	call .Func_11a98
-	ld a, [wdafd]
+	ld a, [wIntroDistortionCounter]
 	and a
 	jr nz, .asm_11a3c
 	scf
@@ -4905,7 +4905,7 @@ AnimateSubtitleEnter:
 .Func_11a98:
 	push de
 	ld hl, Data_11dd2
-	ld de, wdac1
+	ld de, wIntroLineSCXBuffer
 	ld a, [wIntroStateCounter]
 	ld c, a ; unused
 	ld a, $20
@@ -4927,12 +4927,12 @@ AnimateSubtitleEnter:
 	rr c ; /32
 
 	ld hl, $0
-	ld a, [wdafd]
+	ld a, [wIntroDistortionCounter]
 .loop_multiply
 	add hl, bc
 	dec a
 	jr nz, .loop_multiply
-	; hl = bc * wdafd
+	; hl = bc * wIntroDistortionCounter
 
 	ld a, h
 	ld [de], a
@@ -4947,7 +4947,7 @@ AnimateSubtitleEnter:
 	ld a, [wIntroStateCounter]
 	and $03
 	ret nz
-	ld hl, wdafd
+	ld hl, wIntroDistortionCounter
 	dec [hl]
 	ret
 
@@ -5013,8 +5013,8 @@ AnimateSubtitleExit:
 
 .Animate:
 	xor a
-	ld [wdabd], a
-	ld [wdabf], a
+	ld [wTitleAnimSCXUpper], a
+	ld [wTitleAnimSCXMiddle], a
 	call .ApplyEffect
 	ret c
 	ld hl, .ClearBoxParams
@@ -5132,7 +5132,7 @@ AnimateSubtitleExit:
 	cp $2f
 	jr c, .asm_11be8
 	call WaitForLCDOff
-	ld a, [wdabd]
+	ld a, [wTitleAnimSCXUpper]
 	ldh [rSCX], a
 	ei
 .asm_11bf7
@@ -5145,7 +5145,7 @@ AnimateSubtitleExit:
 	cp $48
 	jr c, .asm_11bfe
 	call WaitForLCDOff
-	ld a, [wdabf]
+	ld a, [wTitleAnimSCXMiddle]
 	ldh [rSCX], a
 	ei
 .asm_11c0d
@@ -5161,12 +5161,12 @@ AnimateSubtitleExit:
 	xor a
 	ldh [rSCX], a
 	ei
-	ld a, [wdabd]
+	ld a, [wTitleAnimSCXUpper]
 	add 3
-	ld [wdabd], a
-	ld a, [wdabf]
+	ld [wTitleAnimSCXUpper], a
+	ld a, [wTitleAnimSCXMiddle]
 	add -3
-	ld [wdabf], a
+	ld [wTitleAnimSCXMiddle], a
 	dec c
 	jr nz, .asm_11bd2
 	scf
@@ -5245,7 +5245,7 @@ ChooseTitleScreenCards:
 
 ScrollIntroCard:
 	ldh a, [rSCX]
-	ld [wdabd], a
+	ld [wTitleAnimSCXUpper], a
 	ld c, 28
 .asm_11cbc
 	call DoFrame
@@ -5268,7 +5268,7 @@ ScrollIntroCard:
 	cp $36
 	jr c, .asm_11cd3
 	call WaitForLCDOff
-	ld a, [wdabd]
+	ld a, [wTitleAnimSCXUpper]
 	ldh [rSCX], a
 	ei
 .asm_11ce2
@@ -5284,9 +5284,9 @@ ScrollIntroCard:
 	xor a
 	ldh [rSCX], a
 	ei
-	ld a, [wdabd]
+	ld a, [wTitleAnimSCXUpper]
 	add 4
-	ld [wdabd], a
+	ld [wTitleAnimSCXUpper], a
 	dec c
 	jr nz, .asm_11cbc
 	scf
@@ -5908,7 +5908,7 @@ DrawLoadedCard:
 	ld a, b
 	ld [wCardTilemapOffset], a
 	ld a, c
-	ld [wddf5], a
+	ld [wCardAttrMapOffset], a
 	ld b, d
 	ld c, e
 	call BCCoordToBGMap0Address
@@ -5951,8 +5951,8 @@ DrawLoadedCard:
 .ApplyAttrmap:
 	push de
 	ld hl, wCardAttrMap
-	ld de, wddc4
-	ld a, [wddf5]
+	ld de, wCardAttrMapBuffer
+	ld a, [wCardAttrMapOffset]
 	ld c, a
 	ld b, $30 ; card size in tiles
 .asm_134f8
@@ -5966,7 +5966,7 @@ DrawLoadedCard:
 	dec b
 	jr nz, .asm_134f8
 	pop de
-	ld hl, wddc4
+	ld hl, wCardAttrMapBuffer
 	call .CopyCardDataToBGMap
 	ret
 
@@ -6398,7 +6398,7 @@ PlayerGenderSelection:
 	push de
 	push hl
 	xor a
-	ld [wde64], a
+	ld [wPlayerGenderMenuCursor], a
 	call .Show
 	pop hl
 	pop de
@@ -6433,7 +6433,7 @@ PlayerGenderSelection:
 	ld hl, .MenuParams
 	lb de, 2, 2
 	call LoadMenuBoxParams
-	ld a, [wde64]
+	ld a, [wPlayerGenderMenuCursor]
 	farcall DrawMenuBox
 	lb de, 0, 12
 	lb bc, 20, 6
@@ -6451,9 +6451,9 @@ PlayerGenderSelection:
 .HandleSelection:
 	ldtx hl, ChoosePlayerGenderText
 	call PrintTextInWideTextBox
-	ld a, [wde64]
+	ld a, [wPlayerGenderMenuCursor]
 	farcall HandleMenuBox
-	ld [wde64], a
+	ld [wPlayerGenderMenuCursor], a
 	inc a
 	ldtx hl, ConfirmPlayerGenderMaleText
 	dec a
@@ -6463,7 +6463,7 @@ PlayerGenderSelection:
 	ld a, $1
 	call DrawWideTextBox_PrintTextWithYesOrNoMenu
 	jr c, .HandleSelection
-	ld a, [wde64]
+	ld a, [wPlayerGenderMenuCursor]
 	call SetPlayerGender
 	ret
 

--- a/src/engine/bank05.asm
+++ b/src/engine/bank05.asm
@@ -246,7 +246,7 @@ StoreAICardListPointers:
 
 Func_14178:
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 	call AIDecideBenchPokemonToSwitchTo
 	ret
 
@@ -5235,10 +5235,10 @@ AIDecideWhetherToRetreat:
 
 	farcall AIDeckSpecificRetreatLogic
 	ld [wAIScore], a
-	ld a, [wd032]
+	ld a, [wAIAttackNonDamageCount]
 	or a
 	jr z, .check_status
-	; add wd032 * 8 to score
+	; add wAIAttackNonDamageCount * 8 to score
 	srl a
 	srl a
 	sla a ; *8
@@ -6617,7 +6617,7 @@ Func_167e5:
 	ld a, OPPACTION_ATTEMPT_RETREAT
 	farcall AIMakeDecision
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 	ret
 .set_carry
 	scf
@@ -6892,7 +6892,7 @@ Func_16af1:
 ; check if the card can use any attacks
 ; and if any of those attacks can KO
 	xor a
-	ld [wd07b], a
+	ld [wAIDefenderCanKOCandidate], a
 	ld [wSelectedAttack], a ; FIRST_ATTACK_OR_PKMN_POWER
 	call CheckIfSelectedAttackIsUnusable
 	jr nc, .can_attack
@@ -6902,18 +6902,18 @@ Func_16af1:
 	jr c, .cant_attack_or_ko
 .can_attack
 	ld a, $01
-	ld [wd061], a
+	ld [wAIBenchCandidateCanAttack], a
 	call CheckIfAnyAttackKnocksOutDefendingCard
 	jr nc, .check_evolution_attacks
 	call CheckIfSelectedAttackIsUnusable
 	jr c, .check_evolution_attacks
 	ld a, $01
-	ld [wd063], a
+	ld [wAIBenchCandidateCanKO], a
 	jr .check_evolution_attacks
 .cant_attack_or_ko
 	xor a
-	ld [wd061], a
-	ld [wd063], a
+	ld [wAIBenchCandidateCanAttack], a
+	ld [wAIBenchCandidateCanKO], a
 
 ; check evolution to see if it can use any of its attacks:
 ; if it can, raise AI score;
@@ -6955,7 +6955,7 @@ Func_16af1:
 	call AIEncourage
 	jr .check_evolution_ko
 .evolution_cant_attack
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	or a
 	jr z, .check_evolution_ko
 	ld a, 2
@@ -6972,7 +6972,7 @@ Func_16af1:
 ; if evolution can't KO but the current card can, lower AI score;
 ; if evolution can KO as well, raise AI score.
 .check_evolution_ko
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	or a
 	jr z, .check_defending_can_ko_evolution
 	ld a, [wTempAI]
@@ -6989,7 +6989,7 @@ Func_16af1:
 	call AIEncourage
 	jr .check_defending_can_ko_evolution
 .evolution_cant_ko
-	ld a, [wd063]
+	ld a, [wAIBenchCandidateCanKO]
 	or a
 	jr z, .check_defending_can_ko_evolution
 	ld a, 20
@@ -7007,7 +7007,7 @@ Func_16af1:
 	ld a, 10
 	call AIDiscourage
 	ld a, $01
-	ld [wd07b], a
+	ld [wAIDefenderCanKOCandidate], a
 
 ; if evolution can't damage player's Mr Mime, lower AI score
 .check_mr_mime
@@ -7041,7 +7041,7 @@ Func_16af1:
 	farcall CheckIfDefendingPokemonCanKnockOut
 	jr nc, .check_status
 	; encourage unless it can KO the evolution as well
-	ld a, [wd07b]
+	ld a, [wAIDefenderCanKOCandidate]
 	or a
 	jr nz, .check_status
 	ld a, 5
@@ -7355,12 +7355,12 @@ AIProcessEnergyCards:
 	ldh a, [hTempPlayAreaLocation_ff9d]
 	add DUELVARS_ARENA_CARD
 	get_turn_duelist_var
-	ld [wd061], a
+	ld [wAIBenchCandidateCanAttack], a
 	farcall GetAttacksEnergyCostBits
 	ld hl, wDuelTempList
 	farcall CheckEnergyFlagsNeededInList
 	jp nc, .store_score
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	farcall CheckIfPokemonEvolutionIsFoundInHand
 	jr nc, .check_venusaur
 	ld [wTempAI], a ; store evolution card found
@@ -7565,7 +7565,7 @@ AIProcessEnergyCards:
 
 .skip_boss_deck
 	ld a, 1
-	ld [wd07c], a
+	ld [wAIBenchEnergyScoreBonus], a
 
 ; add AI score for both attacks,
 ; according to their energy requirements.
@@ -7715,7 +7715,7 @@ DetermineAIScoreOfAttackEnergyRequirement:
 
 .check_color_needed
 	push bc
-	ld hl, wd07c
+	ld hl, wAIBenchEnergyScoreBonus
 	ld a, [hl]
 	call AIEncourage
 	dec [hl]
@@ -8547,7 +8547,7 @@ AIProcessAttacks:
 
 .can_damage
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 	jr .use_attack
 
 .check_damage_bench
@@ -8557,7 +8557,7 @@ AIProcessAttacks:
 	jr c, .can_damage
 
 ; cannot damage either Defending Pokemon or Bench
-	ld hl, wd032
+	ld hl, wAIAttackNonDamageCount
 	inc [hl]
 
 ; return carry if attack is chosen
@@ -8580,7 +8580,7 @@ AIProcessAttacks:
 
 ; return no carry if no viable attack.
 .failed_to_use
-	ld hl, wd032
+	ld hl, wAIAttackNonDamageCount
 	inc [hl]
 	or a
 	ret

--- a/src/engine/bank06.asm
+++ b/src/engine/bank06.asm
@@ -5607,7 +5607,7 @@ InputName:
 	call Set_OBJ_8x8
 
 	xor a
-	ld [wd3ef], a
+	ld [wNamingScreenCursorRow], a
 	ld [wTileMapFill], a
 	call EmptyScreen
 	call ZeroObjectPositions
@@ -6093,7 +6093,7 @@ DrawSymbolAtCharPosition:
 	call GetCharInfoFromPos
 	ld a, [hli] ; y
 	ld c, a
-	ld a, [wd3ef]
+	ld a, [wNamingScreenCursorRow]
 	or a
 	jr z, .asm_1b1ae
 	inc c
@@ -6123,7 +6123,7 @@ UpdateNameTextCursor:
 	ld a, [wMenuInvisibleCursorTile]
 	cp b
 	jr z, .done ; cursor is invisible, done
-	ld a, [wd3ef]
+	ld a, [wNamingScreenCursorRow]
 	or a
 	jr nz, .asm_1b201
 

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -1111,7 +1111,7 @@ Func_1c799:
 .asm_1c7ad
 	call FlushAllPalettes
 	ld a, $02
-	ld [wd9de], a
+	ld [wPalFadeStepStatus], a
 	ret
 
 Func_1c7b6:
@@ -1127,7 +1127,7 @@ Func_1c7b6:
 .asm_1c7ca
 	call FlushAllPalettes
 	ld a, $01
-	ld [wd9de], a
+	ld [wPalFadeStepStatus], a
 	ret
 
 ; de = 15-bit palette colors
@@ -3387,15 +3387,15 @@ ShowCoinReceivedScreen:
 	call ResumeSong_ClearTemp
 	call WaitForWideTextBoxInput
 	farcall FadeToWhiteAndUnsetFrameFunc
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	set 0, a
-	ld [wd693], a
-	ld a, [wd693]
+	ld [wGfxCacheFlags], a
+	ld a, [wGfxCacheFlags]
 	res 2, a
-	ld [wd693], a
-	ld a, [wd693]
+	ld [wGfxCacheFlags], a
+	ld a, [wGfxCacheFlags]
 	res 1, a
-	ld [wd693], a
+	ld [wGfxCacheFlags], a
 	ret
 
 .DrawScreen:
@@ -3993,8 +3993,8 @@ Func_1dfb9::
 	ld [wNumActiveAnimations], a
 	ld [wDuelAnimSetScreen], a
 	ld [wDuelAnimLocationParam], a
-	ld [wdcf0], a
-	ld [wdc57], a
+	ld [wDuelAnimCallbackActive], a
+	ld [wDuelAnimFrameFuncActive], a
 	ld a, $ff
 	ld [wActiveScreenAnim], a
 
@@ -4180,7 +4180,7 @@ Func_1e088::
 	ld a, [wActiveScreenAnim]
 	cp $ff
 	ret nz
-	ld a, [wdcf0]
+	ld a, [wDuelAnimCallbackActive]
 	and a
 	ret nz
 	ld a, [wNumActiveAnimations]
@@ -4193,7 +4193,7 @@ Func_1e088::
 	farcall ClearSpriteAnims
 
 	ld a, [wCurAnimation]
-	ld [wdc5a], a
+	ld [wDuelAnimDispatchID], a
 	cp DUEL_SPECIAL_ANIMS
 	jr c, .not_special
 	call Func_3c8e
@@ -4424,7 +4424,7 @@ Func_1e279:
 	ld a, DUEL_ANIM_SHOW_DAMAGE
 	ld [wCurAnimation], a
 	xor a
-	ld [wdc58], a
+	ld [wDuelAnimSpriteStartDelay], a
 	call Func_1e2b1
 	ld a, [wDuelAnimEffectiveness]
 	bit 0, a
@@ -4432,7 +4432,7 @@ Func_1e279:
 	call Func_1e30d
 .asm_1e293
 	ld a, $12
-	ld [wdc58], a
+	ld [wDuelAnimSpriteStartDelay], a
 	ld a, [wDuelAnimEffectiveness]
 	bit 1, a
 	jr z, .asm_1e2a2
@@ -4530,10 +4530,10 @@ Func_1e324:
 	add -8
 	ld d, a
 	farcall SetSpriteAnimPosition
-	ld a, [wdc58]
+	ld a, [wDuelAnimSpriteStartDelay]
 	farcall SetSpriteAnimStartDelay
 	add $12
-	ld [wdc58], a
+	ld [wDuelAnimSpriteStartDelay], a
 	ret
 
 Func_1e347:
@@ -4545,7 +4545,7 @@ Func_1e347:
 	add -16
 	ld d, a
 	farcall SetSpriteAnimPosition
-	ld a, [wdc58]
+	ld a, [wDuelAnimSpriteStartDelay]
 	farcall SetSpriteAnimStartDelay
 	ret
 
@@ -4749,9 +4749,9 @@ ShakeScreenX_Big:
 	ld hl, BigShakeOffsets
 ShakeScreenX:
 	ld a, l
-	ld [wdcee + 0], a
+	ld [wShakeOffsetTablePtr + 0], a
 	ld a, h
-	ld [wdcee + 1], a
+	ld [wShakeOffsetTablePtr + 1], a
 	ld hl, wScreenAnimUpdatePtr
 	ld [hl], LOW(.UpdateFunc)
 	inc hl
@@ -4775,9 +4775,9 @@ ShakeScreenY_Big:
 	ld hl, BigShakeOffsets
 ShakeScreenY:
 	ld a, l
-	ld [wdcee + 0], a
+	ld [wShakeOffsetTablePtr + 0], a
 	ld a, h
-	ld [wdcee + 1], a
+	ld [wShakeOffsetTablePtr + 1], a
 	ld hl, wScreenAnimUpdatePtr
 	ld [hl], LOW(.UpdateFunc)
 	inc hl
@@ -4798,7 +4798,7 @@ ShakeScreenY:
 ; depending on the value of wScreenAnimDuration
 ; returns carry if displacement was updated
 UpdateShakeOffset:
-	ld hl, wdcee
+	ld hl, wShakeOffsetTablePtr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -4809,9 +4809,9 @@ UpdateShakeOffset:
 	push hl
 	inc hl
 	ld a, l
-	ld [wdcee + 0], a
+	ld [wShakeOffsetTablePtr + 0], a
 	ld a, h
-	ld [wdcee + 1], a
+	ld [wShakeOffsetTablePtr + 1], a
 	pop hl
 	scf
 	ret
@@ -7067,7 +7067,7 @@ Func_1f57b::
 	push bc
 	push de
 	push hl
-	ld a, [wdd75]
+	ld a, [wScreenShakeType]
 	and a
 	jr z, .asm_1f588
 	call .Func_1f58d
@@ -7088,7 +7088,7 @@ Func_1f57b::
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [wdd76]
+	ld a, [wScreenShakeIndex]
 	add a ; *2
 	ld c, a
 	add hl, bc
@@ -7104,22 +7104,22 @@ Func_1f57b::
 	ldh a, [hSCY]
 	sub c
 	ldh [hSCY], a
-	ld hl, wdd76
+	ld hl, wScreenShakeIndex
 	inc [hl]
 	ret
 
 .asm_1f5b6
 	xor a
-	ld [wdd76], a
-	ld a, [wdd77]
+	ld [wScreenShakeIndex], a
+	ld a, [wScreenShakeRepeatCount]
 	and a
 	jr z, .asm_1f5c5
 	dec a
-	ld [wdd77], a
+	ld [wScreenShakeRepeatCount], a
 	ret nz
 .asm_1f5c5
 	xor a
-	ld [wdd75], a
+	ld [wScreenShakeType], a
 	ret
 
 .OffsetPointers:
@@ -7173,18 +7173,18 @@ Func_1f57b::
 	db $80 ; end
 
 ; input: a, c
-; set [wdd75] = a, [wdd76] = 0, [wdd77] = c
+; set [wScreenShakeType] = a, [wScreenShakeIndex] = 0, [wScreenShakeRepeatCount] = c
 Set3FromwDD75:
 	push af
-	ld [wdd75], a
+	ld [wScreenShakeType], a
 	ld a, c
-	ld [wdd77], a
+	ld [wScreenShakeRepeatCount], a
 	xor a
-	ld [wdd76], a
+	ld [wScreenShakeIndex], a
 	pop af
 	ret
 
-; set [wdd75] = [wdd76] = 0, [wdd77] = c
+; set [wScreenShakeType] = [wScreenShakeIndex] = 0, [wScreenShakeRepeatCount] = c
 Func_1f61a:
 	push af
 	ld a, 0
@@ -7193,7 +7193,7 @@ Func_1f61a:
 	ret
 
 GetwDD75:
-	ld a, [wdd75]
+	ld a, [wScreenShakeType]
 	and a
 	ret
 

--- a/src/engine/bank08.asm
+++ b/src/engine/bank08.asm
@@ -371,7 +371,7 @@ Func_209fc:
 	ret
 .asm_20aa0
 	ld a, $ff
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	xor a
 	ld [wd084], a
 	ld e, a
@@ -386,7 +386,7 @@ Func_209fc:
 	add DUELVARS_ARENA_CARD_HP
 	call GetNonTurnDuelistVariable
 	ld b, a
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	inc b
 	cp b
 	jr c, .asm_20ab0
@@ -394,7 +394,7 @@ Func_209fc:
 	jr nc, .asm_20ab0
 	dec b
 	ld a, b
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	ld a, e
 	ld [wd084], a
 	jr .asm_20ab0

--- a/src/engine/bank09.asm
+++ b/src/engine/bank09.asm
@@ -5640,9 +5640,9 @@ _TossCoin::
 	ldh a, [hWhoseTurn]
 	ld [wDuelAnimDuelistSide], a
 	ld a, [wOppCoin]
-	ld [wdce1], a
+	ld [wAnimOppCoin], a
 	ld a, [wPlayerCoin]
-	ld [wdce0], a
+	ld [wAnimPlayerCoin], a
 	call LoadDuelAnimationToBuffer
 	ret
 

--- a/src/engine/bank0a.asm
+++ b/src/engine/bank0a.asm
@@ -1825,8 +1825,8 @@ AISelectSpecialAttackParameters:
 
 AIChooseRagingThunderTarget:
 	xor a
-	ld [wd06a], a
-	ld [wd06b], a
+	ld [wAIBestTargetLocation], a
+	ld [wAIBestTargetScore], a
 	ld e, a ; PLAY_AREA_ARENA
 	ld a, DUELVARS_BENCH
 	get_turn_duelist_var
@@ -1841,20 +1841,20 @@ AIChooseRagingThunderTarget:
 	ld a, e
 	add DUELVARS_ARENA_CARD_HP
 	get_turn_duelist_var
-	ld hl, wd06b
+	ld hl, wAIBestTargetScore
 	cp [hl]
 	jr c, .loop_bench ; has less remaining HP
 	ld [hl], a
 	ld a, e
-	ld [wd06a], a
+	ld [wAIBestTargetLocation], a
 	jr .loop_bench
 .break
-	ld a, [wd06a]
+	ld a, [wAIBestTargetLocation]
 	or a
 	ret z ; has no choice other than Arena card
 
 	; picked a Bench card, will it KO?
-	ld a, [wd06b]
+	ld a, [wAIBestTargetScore]
 	cp 30
 	jr nc, .got_target ; it won't
 	; it will, check whether to pick Arena card instead
@@ -1867,7 +1867,7 @@ AIChooseRagingThunderTarget:
 	xor a ; PLAY_AREA_ARENA
 	ret
 .got_target
-	ld a, [wd06a]
+	ld a, [wAIBestTargetLocation]
 	ret
 
 AILookForShortCircuitTargetToKO:
@@ -1944,8 +1944,8 @@ CountNumberAttachedWaterEnergies:
 
 AIChooseShortCircuitTarget:
 	xor a
-	ld [wd06a], a
-	ld [wd06b], a
+	ld [wAIBestTargetLocation], a
+	ld [wAIBestTargetScore], a
 	farcall IsPlayerArenaCardImmune
 	jr nc, .include_arena
 ; exclude Arena
@@ -1973,22 +1973,22 @@ AIChooseShortCircuitTarget:
 	pop de
 	call CountNumberAttachedWaterEnergies
 	ld b, a
-	ld a, [wd06b]
+	ld a, [wAIBestTargetScore]
 	cp b
 	jr nc, .next_play_area
 	ld a, b
-	ld [wd06b], a
+	ld [wAIBestTargetScore], a
 	ld a, e
-	ld [wd06a], a
+	ld [wAIBestTargetLocation], a
 .next_play_area
 	inc e
 	ld a, e
 	cp d
 	jr nz, .loop_play_area
 	call SwapTurn
-	ld a, [wd06b]
+	ld a, [wAIBestTargetScore]
 	ld b, a
-	ld a, [wd06a]
+	ld a, [wAIBestTargetLocation]
 	ret
 
 ; used by AI to determine which Pokémon it should favor in the bench
@@ -3323,7 +3323,7 @@ ReadCurAutoDeckName:
 
 ; de = text ID
 Func_2bc4f:
-	ld hl, wd548
+	ld hl, wDeckScreenTextPtr
 	ld [hl], e
 	inc hl
 	ld [hl], d
@@ -3334,7 +3334,7 @@ Func_2bc4f:
 .asm_2bc5c
 	ld hl, .MenuParameters
 	call InitializeMenuParameters
-	ld hl, wd548
+	ld hl, wDeckScreenTextPtr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -3385,7 +3385,7 @@ _HandleAutoDeckMenu:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 .wait_input
 	call DoFrame
 	farcall HandleScrollMenu

--- a/src/engine/bank0c.asm
+++ b/src/engine/bank0c.asm
@@ -491,7 +491,7 @@ Func_30343:
 	ld hl, Data_3056a
 	add_hl_a
 	ld a, [hli]
-	ld [wd680], a
+	ld [wGRIslandScrollConfig], a
 	ld a, [hli]
 	ld [wOWScrollX], a
 	ld a, [hl]
@@ -506,7 +506,7 @@ Func_3035f:
 	ld a, c
 	ld [wOWScrollSpeed], a
 	ld a, [hli]
-	ld [wd680], a
+	ld [wGRIslandScrollConfig], a
 	ld a, [hli]
 	ld d, a
 	ld a, [hl]
@@ -530,7 +530,7 @@ Func_3035f:
 	ret
 
 Func_30398:
-	ld a, [wd680]
+	ld a, [wGRIslandScrollConfig]
 	cp 2
 	jr z, .scroll_if_challenge_hall
 	or a

--- a/src/engine/bank0e.asm
+++ b/src/engine/bank0e.asm
@@ -7,7 +7,7 @@
 ;	- AI_ENERGY_TRANS_TO_BENCH: transfers all Grass Energy cards from
 ;	Arena Pokemon to Bench in case Arena card will be KO'd.
 HandleAIEnergyTrans:
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 
 	farcall StubbedAIChooseRandomlyNotToDoAction
 	ret c
@@ -25,7 +25,7 @@ HandleAIEnergyTrans:
 	bank1call CheckIsIncapableOfUsingPkmnPower
 	ret c ; return if cannot use Energy Trans
 
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	cp AI_ENERGY_TRANS_RETREAT
 	jr z, .check_retreat
 
@@ -44,7 +44,7 @@ HandleAIEnergyTrans:
 ; use Energy Trans to transfer number of Grass energy cards
 ; equal to input a from the Bench to the Arena card.
 .TransferEnergyToArena
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 
 ; look for VenusaurLv67 in Play Area
 ; so that its PKMN Power can be used.
@@ -78,7 +78,7 @@ HandleAIEnergyTrans:
 
 	xor a
 	ldh [hAIEnergyTransPlayAreaLocation], a
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	ld d, a
 
 	ld e, 0
@@ -309,7 +309,7 @@ AIEnergyTransTransferEnergyToBench:
 .use_pkmn_power
 	ld a, b
 	ldh [hTemp_ffa0], a
-	ld [wd07f], a
+	ld [wAIEnergyTransVenusaurLocation], a
 	ld a, OPPACTION_USE_PKMN_POWER
 	farcall AIMakeDecision
 	ld a, OPPACTION_EXECUTE_PKMN_POWER_EFFECT
@@ -319,7 +319,7 @@ AIEnergyTransTransferEnergyToBench:
 .loop_energy
 	xor a
 	ldh [hAIPkmnPowerEffectParam], a
-	ld a, [wd07f]
+	ld a, [wAIEnergyTransVenusaurLocation]
 	ldh [hTemp_ffa0], a
 
 	; returns when Arena card has no Grass energy cards attached.
@@ -685,7 +685,7 @@ HandleAIShift:
 	ld b, a
 	call SwapTurn
 	bank1call GetArenaCardWeakness
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	call SwapTurn
 	or a
 	ret z ; return if Defending Pokemon has no weakness
@@ -708,7 +708,7 @@ HandleAIShift:
 	farcall AIMakeDecision
 
 ; converts WR_* to appropriate color
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	ld b, 0
 .loop_color
 	bit 7, a
@@ -758,13 +758,13 @@ HandleAIShift:
 	ld a, [hli]
 	jr nc, .loop_random_color
 	call TranslateColorToWR
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	jr .found
 
 ; returns carry if turn Duelist has a Pokemon
-; with same color as wd082.
+; with same color as wAIEnergyTransMode.
 .CheckWhetherTurnDuelistHasWRColor
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	ld b, a
 	ld a, DUELVARS_ARENA_CARD
 	get_turn_duelist_var
@@ -929,7 +929,7 @@ HandleAIStrangeBehavior:
 	or a
 	ret z ; return if Arena card has no damage counters
 
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	ldh a, [hTemp_ffa0]
 	add DUELVARS_ARENA_CARD_HP
 	get_turn_duelist_var
@@ -938,7 +938,7 @@ HandleAIStrangeBehavior:
 
 ; if Slowbro can't receive all damage counters,
 ; only transfer remaining HP - 10 damage
-	ld hl, wd082
+	ld hl, wAIEnergyTransMode
 	cp [hl]
 	jr c, .use_strange_behavior
 	ld a, [hl] ; can receive all damage counters
@@ -2286,7 +2286,7 @@ HandleAIDamageSwap:
 	ret z ; return if Arena Card has no damage
 
 	farcall ConvertHPToCounters
-	ld [wd082], a
+	ld [wAIEnergyTransMode], a
 	farcall FindAlakazamLv42WithActivePkmnPowerInPlayArea
 	ld [wd084], a
 
@@ -2305,7 +2305,7 @@ HandleAIDamageSwap:
 	ld a, OPPACTION_EXECUTE_PKMN_POWER_EFFECT
 	farcall AIMakeDecision
 
-	ld a, [wd082]
+	ld a, [wAIEnergyTransMode]
 	ld e, a
 .loop_damage
 	ld d, 30
@@ -2974,7 +2974,7 @@ Func_3926a:
 
 ; a = number of energy cards attached
 Func_392db:
-	ld [wd074], a
+	ld [wAITempCardCount], a
 	ld a, [wOpponentDeckID]
 	cp ROCK_BLAST_DECK_ID
 	jr z, .rock_blast_deck
@@ -2987,9 +2987,9 @@ Func_392db:
 
 .compare
 	ld b, a ; max number of energy cards
-	ld a, [wd074]
+	ld a, [wAITempCardCount]
 	cp b
-	; carry if wd074 < b
+	; carry if wAITempCardCount < b
 	ret
 
 .rock_blast_deck
@@ -3065,10 +3065,10 @@ Func_3934d:
 ; - de = card ID
 ; - b = starting Play Area location
 ; outputs:
-; - a and [wd074] = card count
+; - a and [wAITempCardCount] = card count
 CountCardIDInTurnDuelistPlayArea:
 	xor a
-	ld [wd074], a
+	ld [wAITempCardCount], a
 .loop_play_area
 	ld a, DUELVARS_ARENA_CARD
 	add b
@@ -3085,9 +3085,9 @@ CountCardIDInTurnDuelistPlayArea:
 	ld a, e
 	cp c
 	jr nz, .not_equal
-	ld a, [wd074]
+	ld a, [wAITempCardCount]
 	inc a
-	ld [wd074], a
+	ld [wAITempCardCount], a
 .not_equal
 	ld d, b
 	ld e, c
@@ -3097,7 +3097,7 @@ CountCardIDInTurnDuelistPlayArea:
 	cp b
 	jr nz, .loop_play_area
 .done
-	ld a, [wd074]
+	ld a, [wAITempCardCount]
 	ret
 ; 0x393b4
 
@@ -3283,7 +3283,7 @@ CheckEvolutionaryLightTarget:
 	pop de
 	pop bc
 	ret nc ; not found in deck
-	ld [wd073], a ; deck index
+	ld [wAITempFoundDeckIndex], a ; deck index
 	push bc
 	push de
 	ld d, b
@@ -3296,7 +3296,7 @@ CheckEvolutionaryLightTarget:
 	call CheckIfCardIDIsInHandOrPlayArea
 	pop de
 	jr c, .no_carry
-	ld a, [wd073]
+	ld a, [wAITempFoundDeckIndex]
 	scf
 	ret
 .no_carry
@@ -3316,7 +3316,7 @@ FindUsableEvolutionInDeck:
 	pop de
 	pop bc
 	ret nc ; card ID 1 not found in deck
-	ld [wd073], a
+	ld [wAITempFoundDeckIndex], a
 	push de
 	ld d, b
 	ld e, c
@@ -3327,7 +3327,7 @@ FindUsableEvolutionInDeck:
 	farcall LookForCardIDInHandList
 	pop bc
 	jr c, .no_carry  ; card ID 1 found in Hand
-	ld a, [wd073]
+	ld a, [wAITempFoundDeckIndex]
 	scf
 	ret
 .no_carry
@@ -3342,14 +3342,14 @@ Func_39a6a:
 	pop de
 	pop bc
 	ret nc
-	ld [wd073], a
+	ld [wAITempFoundDeckIndex], a
 	push bc
 	call CheckIfCardIDIsInHandOrPlayArea
 	pop de
 	jr c, .asm_39a89
 	farcall LookForCardIDInHandList
 	ret nc
-	ld a, [wd073]
+	ld a, [wAITempFoundDeckIndex]
 	scf
 	ret
 .asm_39a89
@@ -4309,7 +4309,7 @@ SECTION "Bank e@6887", ROMX[$6887], BANK[$e]
 Func_3a887:
 	bank1call GetArenaCardColor
 	call TranslateColorToWR
-	ld [wd075], a
+	ld [wAIArenaCardColor], a
 	call SwapTurn
 	ld a, DUELVARS_NUMBER_OF_POKEMON_IN_PLAY_AREA
 	get_turn_duelist_var
@@ -4323,7 +4323,7 @@ Func_3a887:
 	push bc
 	bank1call GetPlayAreaCardWeakness
 	pop bc
-	ld hl, wd075
+	ld hl, wAIArenaCardColor
 	cp [hl]
 	jr nz, .loop_bench
 	; is weak to Arena card
@@ -5035,7 +5035,7 @@ InitDeckMachineDrawingParams:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 	ret
 
 ; handles player input inside the Deck Machine screen
@@ -5326,7 +5326,7 @@ DrawDeckMachineScreen:
 	jr PrintVisibleDeckMachineEntries
 
 ; update wScrollMenuScrollFunc to PrintVisibleAutoDeckMachineEntries
-; and init wd119
+; and init wCardListAllowLeftRight
 UpdateAutoDeckSelectionMenuScroll:
 	ld hl, PrintVisibleAutoDeckMachineEntries
 	ld d, h
@@ -5335,7 +5335,7 @@ UpdateAutoDeckSelectionMenuScroll:
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 	ret
 
 ; variant of PrintVisibleDeckMachineEntries for Auto Deck Machine categories
@@ -7114,7 +7114,7 @@ _HandleAutoDeckSelectionMenu:
 	ld a, TRUE
 	ld [wUnableToScrollDown], a
 	xor a
-	ld [wd119], a
+	ld [wCardListAllowLeftRight], a
 	call UpdateAutoDeckSelectionMenuScroll
 
 .wait_input
@@ -7176,7 +7176,7 @@ _HandleAutoDeckSelectionMenu:
 	ld [wSelectedDeckMachineEntry], a
 	farcall ResetCheckMenuCursorPositionAndBlink
 	xor a
-	ld [wd0cd], a
+	ld [wCheckMenuCursorNavFlags], a
 	call DrawWideTextBox
 	ld hl, .deck_options
 	call PlaceTextItems

--- a/src/engine/bank12.asm
+++ b/src/engine/bank12.asm
@@ -739,7 +739,7 @@ AIMainTurnLogic:
 
 	ld a, AI_TRAINER_CARD_PHASE_17
 	farcall AIProcessHandTrainerCards
-	ld a, [wd033]
+	ld a, [wAISkipAttackCounter]
 	cp $02
 	jr z, .finish_wo_attack
 ; attack if possible, if not,
@@ -936,7 +936,7 @@ AIDoTurn_GeneralNoRetreat:
 
 	ld a, AI_TRAINER_CARD_PHASE_17
 	farcall AIProcessHandTrainerCards
-	ld a, [wd033]
+	ld a, [wAISkipAttackCounter]
 	cp $02
 	jr z, .finish_wo_attack
 ; attack if possible, if not,
@@ -1069,7 +1069,7 @@ AIDeckSpecificEnergyLogic:
 	jp c, .asm_4895d ; can be jr
 	; at least 2 set up bench Pokémon
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48958
 	ld b, $85
 	jp .got_score
@@ -1150,7 +1150,7 @@ AIDeckSpecificEnergyLogic:
 	jr c, .asm_489c1
 	; at least 2 set up bench Pokémon
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 	jr .asm_489bc
 
 .DarkScienceDeck:
@@ -1197,7 +1197,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .asm_48a5b ; Arcanine still needs energy
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48a56
 	ld b, $8d
 	jp .got_score
@@ -1234,7 +1234,7 @@ AIDeckSpecificEnergyLogic:
 	jp nc, .default_score
 	; Charizard can already use all attacks
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48a9d
 	ld b, $8d
 	jp .got_score
@@ -1266,7 +1266,7 @@ AIDeckSpecificEnergyLogic:
 	jp c, .default_score
 	; Vileplume can already use all attacks
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48adf
 	ld b, $8d
 	jp .got_score
@@ -1297,7 +1297,7 @@ AIDeckSpecificEnergyLogic:
 	cp 2
 	jr c, .asm_48b1d
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48b18
 	ld b, $8d
 	jp .got_score
@@ -1328,7 +1328,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .default_score
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48b57
 	ld b, $8d
 	jp .got_score
@@ -1358,7 +1358,7 @@ AIDeckSpecificEnergyLogic:
 	cp 2
 	jr c, .asm_48b9f
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48b9a
 	ld b, $8d
 	jp .got_score
@@ -1392,7 +1392,7 @@ AIDeckSpecificEnergyLogic:
 	farcall FindCardIDInTurnDuelistsPlayArea
 	jr nc, .asm_48be5
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48be0
 	ld b, $8d
 	jp .got_score
@@ -1420,7 +1420,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .default_score
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48c1f
 	ld b, $8d
 	jp .got_score
@@ -1460,7 +1460,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .default_score
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48c75
 	ld b, $8d
 	jp .got_score
@@ -1495,7 +1495,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .default_score
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48cc1
 	ld b, $8d
 	jp .got_score
@@ -1551,7 +1551,7 @@ AIDeckSpecificEnergyLogic:
 	call CheckIfPokemonInBenchHasEnoughEnergy
 	jp nc, .default_score
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48d3e
 	ld b, $8d
 	jp .got_score
@@ -1745,7 +1745,7 @@ AIDeckSpecificEnergyLogic:
 	cp 2
 	jr c, .asm_48eec
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 .asm_48ee7
 	ld b, $8d
 	jp .got_score
@@ -3031,7 +3031,7 @@ Func_49a73:
 	call GetPlayAreaCardAttachedEnergies
 	call SwapTurn
 	ld a, [wTotalAttachedEnergies]
-	ld [wd076], a
+	ld [wAIArenaCardEnergyCount], a
 	ld a, DUELVARS_BENCH
 	call GetNonTurnDuelistVariable
 	ld e, PLAY_AREA_BENCH_1
@@ -3094,7 +3094,7 @@ Func_49a73:
 	call GetPlayAreaCardAttachedEnergies
 	call SwapTurn
 	ld a, [wTotalAttachedEnergies]
-	ld hl, wd076
+	ld hl, wAIArenaCardEnergyCount
 	cp [hl]
 	jr z, .next_bench ; same number of attached energies
 	jr c, .next_bench ; has less attached energies
@@ -3349,23 +3349,23 @@ InitAITurnVars:
 	ld [wAIBarrierFlagCounter], a
 
 .asm_49daf
-	ld a, [wd033]
+	ld a, [wAISkipAttackCounter]
 	or a
 	jr z, .asm_49db9
 	dec a
-	ld [wd033], a
+	ld [wAISkipAttackCounter], a
 .asm_49db9
 	ld a, DUELVARS_ARENA_CARD
 	get_turn_duelist_var
-	ld hl, wd034
+	ld hl, wAIPrevArenaCard
 	cp [hl]
 	jr z, .asm_49dc9
 	ld [hl], a
 	xor a
-	ld [wd035], a
+	ld [wAIArenaCardStreakCount], a
 	jr .done
 .asm_49dc9
-	ld hl, wd035
+	ld hl, wAIArenaCardStreakCount
 	inc [hl]
 .done
 	ret
@@ -4209,7 +4209,7 @@ SECTION "Bank 12@73f3", ROMX[$73f3], BANK[$12]
 ; - a = PLAY_AREA_* constant of target
 ; - carry set if found a target
 AIChooseFollowMeTarget:
-	ld [wd079], a
+	ld [wAIFollowMeExcludeColor], a
 
 	; save value of hTempPlayAreaLocation_ff9d in the stack
 	ldh a, [hTempPlayAreaLocation_ff9d]
@@ -4224,7 +4224,7 @@ AIChooseFollowMeTarget:
 	push bc
 	ld a, e
 	bank1call GetPlayAreaCardColor
-	ld hl, wd079
+	ld hl, wAIFollowMeExcludeColor
 	cp [hl]
 	jr z, .skip_pkmn
 	call GetPlayAreaCardAttachedEnergies

--- a/src/engine/bank13.asm
+++ b/src/engine/bank13.asm
@@ -569,40 +569,40 @@ Func_4c605:
 .asm_4c640
 	ld a, DUELVARS_ARENA_CARD
 	get_turn_duelist_var
-	ld hl, wd036
+	ld hl, wAILastAttackArenaCard
 	cp [hl]
 	jr nz, .no_carry
-	ld a, [wd037]
+	ld a, [wAILastAttackIndex]
 	or a
 	jr nz, .no_carry
-	ld a, [wd038]
+	ld a, [wAIAttackRepeatCount]
 	cp b
 	jr c, .no_carry
 .set_carry
 	xor a
-	ld [wd032], a
+	ld [wAIAttackNonDamageCount], a
 	scf
 	ret
 
 Func_4c65b:
 	ld a, DUELVARS_ARENA_CARD
 	get_turn_duelist_var
-	ld hl, wd036
+	ld hl, wAILastAttackArenaCard
 	cp [hl]
 	jr nz, .asm_4c66e
 	inc hl
 	ld a, [wSelectedAttack]
-	cp [hl] ; wd037
+	cp [hl] ; wAILastAttackIndex
 	jr nz, .asm_4c66f
 	inc hl
-	inc [hl] ; wd038
+	inc [hl] ; wAIAttackRepeatCount
 	ret
 .asm_4c66e
 	ld [hli], a
 .asm_4c66f
 	ld a, [wSelectedAttack]
-	ld [hli], a ; wd037
-	ld [hl], 1 ; wd038
+	ld [hli], a ; wAILastAttackIndex
+	ld [hl], 1 ; wAIAttackRepeatCount
 	ret
 ; 0x4c676
 
@@ -734,7 +734,7 @@ SECTION "Bank 13@4925", ROMX[$4925], BANK[$13]
 
 AIUpdatePortrait:
 	ld a, -1
-	ld [wd061], a
+	ld [wAIBenchCandidateCanAttack], a
 	ld a, [wDuelFinished]
 	or a
 	jr z, .duel_ongoing
@@ -867,8 +867,8 @@ AIUpdatePortrait:
 	; set sad portrait if no more deck cards
 	call DrawCardFromDeck
 	jp c, .set_sad_portrait
-	ld [wd061], a
-	ld a, [wd061] ; unnecessary
+	ld [wAIBenchCandidateCanAttack], a
+	ld a, [wAIBenchCandidateCanAttack] ; unnecessary
 	call GetCardIDFromDeckIndex
 	cp16 PROFESSOR_OAK
 	jp z, .set_happy_based_on_personality
@@ -917,7 +917,7 @@ AIUpdatePortrait:
 	ld a, [wLoadedCard1Type]
 	or TYPE_ENERGY
 	ld [wTempCardType], a
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	farcall CheckIfEnergyIsUseful
 	pop bc
 	jr c, .set_happy_based_on_personality
@@ -928,7 +928,7 @@ AIUpdatePortrait:
 	jr .loop_play_area_1
 
 .pkmn_card
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	call LoadCardDataToBuffer1_FromDeckIndex
 	ld a, [wLoadedCard1Stage]
 	or a
@@ -937,7 +937,7 @@ AIUpdatePortrait:
 	get_turn_duelist_var
 	dec a
 	ld e, a
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	ld d, a
 .loop_play_area_2
 	call CheckIfEvolvesInto
@@ -1029,7 +1029,7 @@ AIUpdatePortrait:
 .finished
 	; if drew a card to peek,
 	; then put it back in the deck
-	ld a, [wd061]
+	ld a, [wAIBenchCandidateCanAttack]
 	cp -1
 	ret z
 	call ReturnCardToDeck

--- a/src/engine/bank4b.asm
+++ b/src/engine/bank4b.asm
@@ -163,9 +163,9 @@ Func_12c0b7:
 	ld c, $00 ; Tiles0
 	call LoadTilemap
 	ld a, b
-	ld [wd7dc], a ; width
+	ld [wLoadedBGMapWidth], a ; width
 	ld a, c
-	ld [wd7dd], a ; height
+	ld [wLoadedBGMapHeight], a ; height
 	pop hl
 	pop de
 	pop bc
@@ -185,14 +185,14 @@ Func_12c0ce::
 	sla d ; *2
 	sla e ; *2
 	call Func_12c0fc
-	ld hl, wd852
+	ld hl, wOWTilemapOverlayCount
 	ld a, [hl]
 	inc [hl]
 	ld c, a
 	sla c
 	sla c ; *4
 	ld b, $00
-	ld hl, wd853
+	ld hl, wOWTilemapOverlayBuffer
 	add hl, bc
 	pop de
 	pop bc
@@ -249,7 +249,7 @@ LoadTilemap::
 	ld a, c
 	ld [wBGMapHeight], a
 	ld a, l
-	ld [wd7d8], a
+	ld [wOWPermissionsPtr], a
 	ld a, h
 	ld [wd7d9], a
 	pop hl
@@ -337,7 +337,7 @@ LoadTilemap::
 	jr nz, .loop_rows
 	pop de
 
-	ld a, [wd7d8]
+	ld a, [wOWPermissionsPtr]
 	ld l, a
 	ld a, [wd7d9]
 	ld h, a
@@ -369,7 +369,7 @@ Func_12c1c1:
 	; e *= 8
 	ld a, d
 	ld d, $00
-	ld hl, wd6d4
+	ld hl, wDecompressedTilemapPermissions
 	add hl, de
 	ld e, a
 	add hl, de
@@ -439,11 +439,11 @@ LoadOWMap::
 	push hl
 	call GetTilesetGfxPointer
 	ld a, b
-	ld [wd7de], a
+	ld [wLoadedTilesetBank], a
 	ld a, l
-	ld [wd7df + 0], a
+	ld [wLoadedTilesetPtr + 0], a
 	ld a, h
-	ld [wd7df + 1], a
+	ld [wLoadedTilesetPtr + 1], a
 	call Func_3792
 	pop hl
 
@@ -489,15 +489,15 @@ LoadOWMap::
 	farcall SetFontAndTextBoxFrameColor_PreserveRegisters
 
 	; very inefficient...
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	set 0, a
-	ld [wd693], a
-	ld a, [wd693]
+	ld [wGfxCacheFlags], a
+	ld a, [wGfxCacheFlags]
 	res 2, a
-	ld [wd693], a
-	ld a, [wd693]
+	ld [wGfxCacheFlags], a
+	ld a, [wGfxCacheFlags]
 	res 1, a
-	ld [wd693], a
+	ld [wGfxCacheFlags], a
 	ret
 
 ; bc = TILESET_* constant
@@ -579,7 +579,7 @@ UpdateSpriteAnim::
 	ld c, a
 	call GetFramesetData
 	ld a, c
-	ld [wd975], a
+	ld [wSpriteAnimFrameTileOffset], a
 	ld hl, wCurSpriteAnim
 	bit SPRITEANIMSTRUCT_FLAG6_F, [hl] ; SPRITEANIMSTRUCT_FLAGS
 	jr z, .apply_changes
@@ -588,7 +588,7 @@ UpdateSpriteAnim::
 	ld a, [wCurSpriteAnimAnimID + 1]
 	ld b, a
 	call GetSpriteAnimationGfxPointer
-	ld a, [wd975]
+	ld a, [wSpriteAnimFrameTileOffset]
 	ld c, a
 	cp $ff
 	jr z, .apply_changes
@@ -667,18 +667,18 @@ Func_12c36a:
 	ld a, b
 	ld [wCurSpriteAnimFrameDuration], a
 	ld a, c
-	ld [wd975], a
+	ld [wSpriteAnimFrameTileOffset], a
 	ld a, d
-	ld [wd971], a
+	ld [wSpriteAnimFrameXOffset], a
 	ld a, e
-	ld [wd972], a
+	ld [wSpriteAnimFrameYOffset], a
 
-	ld a, [wd971]
+	ld a, [wSpriteAnimFrameXOffset]
 	ld b, a
 	ld a, [wCurSpriteAnimXPos]
 	add b
 	ld [wCurSpriteAnimXPos], a
-	ld a, [wd972]
+	ld a, [wSpriteAnimFrameYOffset]
 	ld b, a
 	ld a, [wCurSpriteAnimYPos]
 	add b
@@ -748,30 +748,30 @@ _LoadOWObject::
 	push bc
 	push de
 	push hl
-	ld [wda8c], a
+	ld [wLoadOWObjectNPCID], a
 	ld a, b
-	ld [wda8d], a
+	ld [wLoadOWObjectDirection], a
 	ld a, d
-	ld [wda94 + 0], a
+	ld [wLoadOWObjectTilePos + 0], a
 	ld a, e
-	ld [wda94 + 1], a
+	ld [wLoadOWObjectTilePos + 1], a
 	farcall _GetNextInactiveOWObject
 	ld a, ACTIVE_OBJ
 	ld [hli], a ; OWOBJSTRUCT_FLAGS
-	ld a, [wda8c]
+	ld a, [wLoadOWObjectNPCID]
 	ld [hli], a ; OWOBJSTRUCT_ID
 	push hl
 	farcall GetNextInactiveSpriteAnim
 	farcall SetNewSpriteAnimValues
-	ld a, [wda94 + 0]
+	ld a, [wLoadOWObjectTilePos + 0]
 	ld d, a
-	ld a, [wda94 + 1]
+	ld a, [wLoadOWObjectTilePos + 1]
 	ld e, a
 	farcall ConvertToSpriteAnimPosition
 	farcall SetSpriteAnimPosition
-	ld a, [wda8d]
+	ld a, [wLoadOWObjectDirection]
 	farcall SetSpriteAnimDirection
-	ld a, [wda8c]
+	ld a, [wLoadOWObjectNPCID]
 	call Func_3bc1
 	push hl
 	ld h, b
@@ -815,7 +815,7 @@ _LoadOWObject::
 	ld b, a
 	farcall SetSpriteAnimOWFrameGroup
 
-	ld a, [wda8d]
+	ld a, [wLoadOWObjectDirection]
 	ld b, a
 	farcall SetSpriteAnimDirection
 
@@ -846,7 +846,7 @@ LoadCurCoinTilemap::
 	push hl
 	push af
 	push de
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	bit 2, a
 	jr nz, .checked_flag
 
@@ -856,12 +856,12 @@ LoadCurCoinTilemap::
 	ld bc, PALETTE_13B
 	call GetPaletteGfxPointer
 	call CopyCurPaletteToPal2
-	ld a, [wd693]
+	ld a, [wGfxCacheFlags]
 	set 2, a
-	ld [wd693], a
-	ld a, [wd693]
+	ld [wGfxCacheFlags], a
+	ld a, [wGfxCacheFlags]
 	res 0, a
-	ld [wd693], a
+	ld [wGfxCacheFlags], a
 
 .checked_flag
 	pop de

--- a/src/engine/credits_commands.asm
+++ b/src/engine/credits_commands.asm
@@ -23,11 +23,11 @@ _PlayCredits::
 	call ClearSpriteAnimsAndSetInitialGraphicsConfiguration
 	call EnableLCD
 	xor a
-	ld [wde4e], a
-	ld [wde4f], a
-	ld [wde50], a
-	ld [wde51], a
-	ld [wde52], a
+	ld [wCreditsScrollXPos], a
+	ld [wCreditsScrollYPos], a
+	ld [wCreditsScrollXTarget], a
+	ld [wCreditsScrollYTarget], a
+	ld [wCreditsScrollSpeed], a
 	farcall RunCreditsCommands
 	call Func_3f61
 	call Func_3f61 ; repeated
@@ -291,50 +291,50 @@ CreditsCmd_PrintBlack:
 
 CreditsCmd_Scroll:
 	ld a, [wCreditsCmdArg1]
-	ld [wde52], a
+	ld [wCreditsScrollSpeed], a
 	ld a, [wCreditsCmdArg2]
-	ld [wde4f], a
+	ld [wCreditsScrollYPos], a
 	ld a, [wCreditsCmdArg3]
-	ld [wde4e], a
+	ld [wCreditsScrollXPos], a
 	ld a, [wCreditsCmdArg4]
-	ld [wde51], a
+	ld [wCreditsScrollYTarget], a
 	ld a, [wCreditsCmdArg5]
-	ld [wde50], a
+	ld [wCreditsScrollXTarget], a
 	; this won't work since the frame function
-	; doesn't actually call wde69
+	; doesn't actually call wCallbackPointer
 	ld hl, Func_3e7a
 	call Func_3f6b
 	ret
 
 Func_13ac1::
 	; current scroll position
-	ld a, [wde4f]
+	ld a, [wCreditsScrollYPos]
 	ld b, a
-	ld a, [wde51]
+	ld a, [wCreditsScrollYTarget]
 	ld c, a
 	or b
 	ret z
 
 	; scrolling speed
-	ld a, [wde52]
+	ld a, [wCreditsScrollSpeed]
 	ld e, a
 
 	; x scrolling
-	ld a, [wde4e]
+	ld a, [wCreditsScrollXPos]
 	ld d, a
 	ld a, b
 	and a
 	call nz, .ApplyScrollingOffset
-	ld [wde4f], a
+	ld [wCreditsScrollYPos], a
 	ldh [hSCX], a
 
 	; y scrolling
-	ld a, [wde50]
+	ld a, [wCreditsScrollXTarget]
 	ld d, a
 	ld a, c
 	and a
 	call nz, .ApplyScrollingOffset
-	ld [wde51], a
+	ld [wCreditsScrollYTarget], a
 	ldh [hSCY], a
 	ret
 

--- a/src/engine/glossary.asm
+++ b/src/engine/glossary.asm
@@ -1,6 +1,6 @@
 Glossary:
 	xor a
-	ld [wd0d2], a
+	ld [wGlossaryReinit], a
 	bank1call SetDefaultPalettes
 	lb de, $38, $9f
 	call SetupText
@@ -8,7 +8,7 @@ Glossary:
 
 .OpenScreen
 	ld a, $01
-	ld [wd0d2], a
+	ld [wGlossaryReinit], a
 
 .asm_186ba
 	xor a
@@ -78,7 +78,7 @@ Glossary:
 	ld a, TRUE
 	ld [wVBlankOAMCopyToggle], a
 	call DoFrame
-	ld a, [wd0d2]
+	ld a, [wGlossaryReinit]
 	or a
 	call nz, .Func_18763
 	farcall HandleMultiDirectionalMenu

--- a/src/engine/play_area_menu.asm
+++ b/src/engine/play_area_menu.asm
@@ -84,12 +84,12 @@ OpenInPlayAreaScreen::
 .selection
 	call ZeroObjectPositionsAndToggleOAMCopy_Bank06
 	xor a
-	ld [wd0d2], a
+	ld [wGlossaryReinit], a
 	ld a, [wMultiDirectionalMenuCursorPosition]
 	ld [wPreservedInPlayAreaCursorPosition], a
 	ld hl, .PositionsJumpTable
 	call JumpToFunctionInTable
-	ld a, [wd0d2]
+	ld a, [wGlossaryReinit]
 	or a
 	jr nz, .on_frame
 	ld a, [wPreservedInPlayAreaCursorPosition]
@@ -320,7 +320,7 @@ OpenInPlayAreaScreen_TurnHolderPrizeCards:
 	call IsCurPrizeCardRemaining
 	jr nz, .found
 	ld a, $01
-	ld [wd0d2], a
+	ld [wGlossaryReinit], a
 	ret
 
 .found
@@ -343,7 +343,7 @@ OpenInPlayAreaScreen_NonTurnHolderPrizeCards:
 	call SwapTurn
 	jr nz, .found
 	ld a, $01
-	ld [wd0d2], a
+	ld [wGlossaryReinit], a
 	ret
 
 .found

--- a/src/home/unsorted.asm
+++ b/src/home/unsorted.asm
@@ -1236,16 +1236,16 @@ Func_3698::
 	ld b, [hl]
 	farcall Func_12c06e
 	ld a, b
-	ld [wd7e7], a
+	ld [wOWTileFrameGfxBank], a
 	pop bc
 	ld a, l
-	ld [wd7e5 + 0], a
+	ld [wOWTileFrameGfxPtr + 0], a
 	ld a, h
-	ld [wd7e5 + 1], a
+	ld [wOWTileFrameGfxPtr + 1], a
 
 	ldh a, [hBankROM]
 	push af
-	ld a, [wd7e7]
+	ld a, [wOWTileFrameGfxBank]
 	call BankswitchROM
 	push bc
 	inc de
@@ -1262,9 +1262,9 @@ Func_3698::
 	ld a, [hld]
 	bit 7, a
 	jr z, .asm_36fe
-	ld a, [wd7e5 + 0]
+	ld a, [wOWTileFrameGfxPtr + 0]
 	ld l, a
-	ld a, [wd7e5 + 1]
+	ld a, [wOWTileFrameGfxPtr + 1]
 	ld h, a
 	ld a, $00
 	ld [de], a
@@ -1317,11 +1317,11 @@ Func_3698::
 Func_372d::
 	ldh a, [hBankROM]
 	push af
-	ld a, [wd7de]
+	ld a, [wLoadedTilesetBank]
 	call BankswitchROM
-	ld a, [wd7df + 0]
+	ld a, [wLoadedTilesetPtr + 0]
 	ld l, a
-	ld a, [wd7df + 1]
+	ld a, [wLoadedTilesetPtr + 1]
 	ld h, a
 	inc hl ; skip length
 	inc hl ;
@@ -1430,9 +1430,9 @@ Func_37ce::
 	push bc
 	push de
 	push hl
-	ld a, [wd896]
+	ld a, [wPalAnimTarget]
 	ld c, a
-	ld a, [wd896 + 1]
+	ld a, [wPalAnimTarget + 1]
 	ld b, a
 	or c
 	jr z, .asm_3823
@@ -1441,12 +1441,12 @@ Func_37ce::
 	farcall $7, $4941
 	cp $02
 	jr z, .asm_3823
-	ld a, [wd899]
+	ld a, [wPalAnimFrameCounter]
 	dec a
-	ld [wd899], a
+	ld [wPalAnimFrameCounter], a
 	jr nz, .asm_3823
-	ld a, [wd898]
-	ld [wd899], a
+	ld a, [wPalAnimFrameDelay]
+	ld [wPalAnimFrameCounter], a
 	farcall GetPaletteGfxPointer
 	ldh a, [hBankROM]
 	push af
@@ -1454,14 +1454,14 @@ Func_37ce::
 	call BankswitchROM
 	ld a, [hli]
 	ld b, a
-	ld a, [wd89a]
+	ld a, [wPalAnimFrameIndex]
 	ld c, a
 	inc a
 	cp b
 	jr nz, .asm_3810
 	xor a
 .asm_3810
-	ld [wd89a], a
+	ld [wPalAnimFrameIndex], a
 	sla c
 	sla c
 	sla c
@@ -1687,7 +1687,7 @@ Func_3924::
 	push bc
 	push de
 	push hl
-	ld [wd68c], a
+	ld [wSpriteAnimTemp], a
 	ldh a, [hBankROM]
 	push af
 	ld a, b
@@ -1699,7 +1699,7 @@ Func_3924::
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [wd68c]
+	ld a, [wSpriteAnimTemp]
 	ld b, a
 	ld a, [hli]
 	ld c, a
@@ -1709,7 +1709,7 @@ Func_3924::
 	ld a, [hli] ; y
 	add e
 	ld e, a
-	ld a, [wd96f]
+	ld a, [wSpriteAnimRenderFlags]
 	bit SPRITE_ANIM_FLAG_Y_FLIP_F, a
 	jr z, .got_y
 	ld a, e
@@ -1726,7 +1726,7 @@ Func_3924::
 	ld a, [hli] ; x
 	add d
 	ld d, a
-	ld a, [wd96f]
+	ld a, [wSpriteAnimRenderFlags]
 	bit SPRITE_ANIM_FLAG_X_FLIP_F, a
 	jr z, .got_x
 	ld a, d
@@ -1744,7 +1744,7 @@ Func_3924::
 	add b
 	ld c, a
 
-	ld a, [wd96f]
+	ld a, [wSpriteAnimRenderFlags]
 	ld b, a
 	ld a, [hli] ; attributes
 	xor b
@@ -1789,7 +1789,7 @@ GetFramesetData::
 	ld d, [hl]
 	inc hl
 	ld e, [hl]
-	ld a, [wd970]
+	ld a, [wSpriteAnimCoordFlags]
 	bit 5, a
 	jr z, .asm_39ba
 	ld a, d
@@ -1797,7 +1797,7 @@ GetFramesetData::
 	inc a
 	ld d, a ; d = -d
 .asm_39ba
-	ld a, [wd970]
+	ld a, [wSpriteAnimCoordFlags]
 	bit 6, a
 	jr z, .asm_39c6
 	ld a, e
@@ -2292,19 +2292,19 @@ ResetAnimationQueue::
 	farcall Func_1dfb9
 	farcall Func_110b9
 	ld a, $01
-	ld [wdc57], a
+	ld [wDuelAnimFrameFuncActive], a
 	pop af
 	ret
 
 FinishQueuedAnimations::
 	push af
-	ld a, [wdc57]
+	ld a, [wDuelAnimFrameFuncActive]
 	and a
 	jr z, .asm_3c60
 	farcall Func_110c2
 .asm_3c60
 	xor a
-	ld [wdc57], a
+	ld [wDuelAnimFrameFuncActive], a
 	ld [wDuelAnimBufferSize], a
 	ld [wDuelAnimBufferCurPos], a
 	farcall Func_1dfb9
@@ -2373,7 +2373,7 @@ Func_3c8e::
 
 Func_3cc3::
 	ld a, $ff
-	ld [wdcf0], a
+	ld [wDuelAnimCallbackActive], a
 	ldh a, [hBankROM]
 	push af
 	ld a, [wDuelAnimReturnBank]
@@ -2382,7 +2382,7 @@ Func_3cc3::
 	pop af
 	call BankswitchROM
 	xor a
-	ld [wdcf0], a
+	ld [wDuelAnimCallbackActive], a
 	ret
 
 Func_3cdd::
@@ -2504,7 +2504,7 @@ LoadBGGraphics::
 	push bc
 	push de
 	ld a, c
-	ld [wdd2f], a
+	ld [wLoadBGGraphicsStartPal], a
 	ldh a, [hBankROM]
 	push af
 	ld a, b
@@ -2522,7 +2522,7 @@ LoadBGGraphics::
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	ld a, [wdd2f]
+	ld a, [wLoadBGGraphicsStartPal]
 	call LoadBGPalette
 
 	; tilemap
@@ -2598,21 +2598,21 @@ CreateSpriteAnim::
 	push bc
 	push de
 	push hl
-	ld [wdd2d], a
+	ld [wCreateSpriteAnimIndex], a
 	ld a, c
-	ld [wdd2e], a
+	ld [wCreateSpriteAnimPalIndex], a
 	ldh a, [hBankROM]
 	push af
 	ld a, b
 	call BankswitchROM
 	push bc
 	push de
-	ld de, wdd25
+	ld de, wCreateSpriteAnimGfxPtr
 	ld bc, $8
 	call CopyDataHLtoDE_SaveRegisters
 	pop de
 	pop bc
-	ld a, [wdd2d]
+	ld a, [wCreateSpriteAnimIndex]
 	cp $ff
 	jr z, .get_inactive
 	farcall GetCthSpriteAnim
@@ -2623,31 +2623,31 @@ CreateSpriteAnim::
 	farcall SetNewSpriteAnimValues
 	farcall SetSpriteAnimPosition
 
-	ld a, [wdd25 + 0]
+	ld a, [wCreateSpriteAnimGfxPtr + 0]
 	ld c, a
-	ld a, [wdd25 + 1]
+	ld a, [wCreateSpriteAnimGfxPtr + 1]
 	ld b, a
 	farcall LoadSpriteAnimGfx
 	farcall SetSpriteAnimTileOffset
 
-	ld a, [wdd27 + 0]
+	ld a, [wCreateSpriteAnimAnimID + 0]
 	ld c, a
-	ld a, [wdd27 + 1]
+	ld a, [wCreateSpriteAnimAnimID + 1]
 	ld b, a
 	farcall SetSpriteAnimAnimation
 
-	ld a, [wdd29 + 0]
+	ld a, [wCreateSpriteAnimFramesetID + 0]
 	ld c, a
-	ld a, [wdd29 + 1]
+	ld a, [wCreateSpriteAnimFramesetID + 1]
 	ld b, a
 	farcall SetAndInitSpriteAnimFrameset
 
-	ld a, [wdd2b + 0]
+	ld a, [wCreateSpriteAnimPalPtr + 0]
 	ld c, a
-	ld a, [wdd2b + 1]
+	ld a, [wCreateSpriteAnimPalPtr + 1]
 	ld b, a
 	farcall GetPaletteGfxPointer
-	ld a, [wdd2e]
+	ld a, [wCreateSpriteAnimPalIndex]
 	ld c, a
 	call LoadGfxPalettes
 
@@ -2826,31 +2826,31 @@ DisableInt_LYCoincidence::
 	pop hl
 	ret
 
-; clears wde69
+; clears wCallbackPointer
 Func_3f61::
 	di
 	xor a
-	ld [wde69 + 0], a
-	ld [wde69 + 1], a
+	ld [wCallbackPointer + 0], a
+	ld [wCallbackPointer + 1], a
 	ei
 	ret
 
-; sets wde69 to function in hl
+; sets wCallbackPointer to function in hl
 Func_3f6b::
 	di
 	push af
 	ld a, l
-	ld [wde69 + 0], a
+	ld [wCallbackPointer + 0], a
 	ld a, h
-	ld [wde69 + 1], a
+	ld [wCallbackPointer + 1], a
 	pop af
 	ei
 	ret
 
-; jumps to wde69 if not null
+; jumps to wCallbackPointer if not null
 Func_3f78::
 	push af
-	ld hl, wde69
+	ld hl, wCallbackPointer
 	ld a, [hli]
 	or [hl]
 	jr nz, .not_null

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -1539,25 +1539,25 @@ wAICardListRetreatBonus:: ; d02e
 wAICardListEnergyBonus:: ; d030
 	ds $2
 
-wd032:: ; d032
+wAIAttackNonDamageCount:: ; d032
 	ds $1
 
-wd033:: ; d033
+wAISkipAttackCounter:: ; d033
 	ds $1
 
-wd034:: ; d034
+wAIPrevArenaCard:: ; d034
 	ds $1
 
-wd035:: ; d035
+wAIArenaCardStreakCount:: ; d035
 	ds $1
 
-wd036:: ; d036
+wAILastAttackArenaCard:: ; d036
 	ds $1
 
-wd037:: ; d037
+wAILastAttackIndex:: ; d037
 	ds $1
 
-wd038:: ; d038
+wAIAttackRepeatCount:: ; d038
 	ds $1
 
 	ds $a
@@ -1633,7 +1633,7 @@ wAICannotDamage:: ; d05f
 wTempAI:: ; d060
 	ds $1
 
-wd061:: ; d061
+wAIBenchCandidateCanAttack:: ; d061
 	ds $1
 
 ; used to temporarily store the card deck index
@@ -1642,7 +1642,7 @@ wd061:: ; d061
 wTempAIPokemonCard:: ; d062
 	ds $1
 
-wd063:: ; d063
+wAIBenchCandidateCanKO:: ; d063
 	ds $1
 
 	ds $4
@@ -1657,10 +1657,10 @@ wSamePokemonEnergyScoreHandled:: ; d06a
 
 NEXTU
 
-wd06a:: ; d06a
+wAIBestTargetLocation:: ; d06a
 	ds $1
 
-wd06b:: ; d06b
+wAIBestTargetScore:: ; d06b
 	ds $1
 
 ENDU
@@ -1673,29 +1673,29 @@ wAISecondAttackDamage:: ; d071
 wd072:: ; d072
 	ds $1
 
-wd073:: ; d073
+wAITempFoundDeckIndex:: ; d073
 	ds $1
 
-wd074:: ; d074
+wAITempCardCount:: ; d074
 	ds $1
 
-wd075:: ; d075
+wAIArenaCardColor:: ; d075
 	ds $1
 
-wd076:: ; d076
+wAIArenaCardEnergyCount:: ; d076
 	ds $1
 
 	ds $2
 
-wd079:: ; d079
+wAIFollowMeExcludeColor:: ; d079
 	ds $1
 
 	ds $1
 
-wd07b:: ; d07b
+wAIDefenderCanKOCandidate:: ; d07b
 	ds $1
 
-wd07c:: ; d07c
+wAIBenchEnergyScoreBonus:: ; d07c
 	ds $1
 
 ; whether AI already retreated this turn or not.
@@ -1709,7 +1709,7 @@ wAIRetreatedThisTurn::  ; d07d
 wAIVenusaurLv67DeckIndex::  ; d07e
 	ds $1
 
-wd07f:: ; d07f
+wAIEnergyTransVenusaurLocation:: ; d07f
 	ds $1
 
 wAIRetreatConsiderStatus:: ; d080
@@ -1722,7 +1722,7 @@ wd081:: ; d081
 ; setting up AI Boss deck
 wAISetupBasicPokemonCount:: ; d082
 wAITempHPRecoverAmount:: ; d082
-wd082:: ; d082
+wAIEnergyTransMode:: ; d082
 	ds $1
 
 	ds $1
@@ -1874,7 +1874,7 @@ wd0cb:: ; d0cb
 wArenaCardsInPlayArea:: ; d0cc
 	ds $1
 
-wd0cd:: ; d0cd
+wCheckMenuCursorNavFlags:: ; d0cd
 	ds $1
 
 wYourOrOppPlayAreaLastCursorPosition:: ; d0ce
@@ -1885,14 +1885,14 @@ wYourOrOppPlayAreaLastCursorPosition:: ; d0ce
 wInPlayAreaFromSelectButton:: ; d0cf
 	ds $1
 
-wd0d0:: ; d0d0
+wPrevTransitionIndex:: ; d0d0
 	ds $1
 
 ; GLOSSARY_* constant
 wGlossaryMenu:: ; d0d1
 	ds $1
 
-wd0d2:: ; d0d2
+wGlossaryReinit:: ; d0d2
 	ds $1
 
 wAttackAnimationIsPlaying:: ; d0d3
@@ -2039,7 +2039,7 @@ wScrollMenuScrollFunc:: ; d115
 wCardListCoords:: ; d117
 	ds $2
 
-wd119:: ; d119
+wCardListAllowLeftRight:: ; d119
 	ds $1
 
 ; the current filter being used
@@ -2054,11 +2054,11 @@ wTempCurMenuItem:: ; d11b
 wTempFilteredCardListNumCursorPositions:: ; d11c
 	ds $1
 
-wd11d:: ; d11d
+wDeckConfigMenuSelection:: ; d11d
 	ds $1
 
 ; tcg1: wced7
-wd11e:: ; d11e
+wCardListScrollEntryBackup:: ; d11e
 	ds $1
 
 wCardListVisibleOffsetBackup:: ; d11f
@@ -2195,7 +2195,7 @@ wFirstOwnedCardIndex:: ; d395
 
 NEXTU
 
-wd394:: ; d394
+wDeckDiagnosisTextPtr:: ; d394
 	ds $2
 
 ENDU
@@ -2237,7 +2237,7 @@ wNamingScreenMode:: ; d3eb
 wTempUnnamedDeckCounter:: ; d3ec
 	ds $3
 
-wd3ef:: ; d3ef
+wNamingScreenCursorRow:: ; d3ef
 	ds $1
 
 	ds $1e
@@ -2324,7 +2324,7 @@ wAutoDeckMachineIndex:: ; d548
 
 NEXTU
 
-wd548:: ; d548
+wDeckScreenTextPtr:: ; d548
 	ds $2
 
 ENDU
@@ -2345,7 +2345,7 @@ wNextGameEvent:: ; d54c
 wNextWarpMap:: ; d54d
 	ds $1
 
-wd54e:: ; d54e
+wNextWarpPlayerCoords:: ; d54e
 	ds $2
 
 wPlayerOWObject:: ; d550
@@ -2360,7 +2360,7 @@ wCurMapScriptsPointer:: ; d552
 ; bit 0: has save data
 ; bit 1: has saved duel + ?
 ; bit 2: has saved duel
-wd554:: ; d554
+wSaveDataFlags:: ; d554
 	ds $1
 
 wCurrentNPCDuelistData:: ; d555
@@ -2521,7 +2521,7 @@ wOverworldScriptPointer:: ; d593
 	ds $2
 
 ; NPC_* ID
-wd595:: ; d595
+wOWObjNPCID:: ; d595
 	ds $1
 
 wOWObjTargetX:: ; d596
@@ -2530,22 +2530,22 @@ wOWObjTargetX:: ; d596
 wOWObjTargetY:: ; d597
 	ds $1
 
-wd598:: ; d598
+wOWObjXVelocityFract:: ; d598
 	ds $1
 
 wOWObjXVelocity:: ; d599
 	ds $1
 
-wd59a:: ; d59a
+wOWObjYVelocityFract:: ; d59a
 	ds $1
 
 wOWObjYVelocity:: ; d59b
 	ds $1
 
-wd59c:: ; d59c
+wOWObjXSubPixel:: ; d59c
 	ds $1
 
-wd59d:: ; d59d
+wOWObjYSubPixel:: ; d59d
 	ds $1
 
 wEventVars:: ; d59e
@@ -2556,7 +2556,7 @@ wGeneralVars:: ; d5d2
 
 ; various temp flags
 ; e.g. blackbox input type flags, evo stage flags, etc.
-wd606:: ; d606
+wPkmnTypeBitfield:: ; d606
 	ds wD606_STRUCT_SIZE
 
 ; NPC_* ID of the active speaker / OW Object
@@ -2693,7 +2693,7 @@ wScenarioDebugMenuCurEventItem:: ; d67d
 wScenarioDebugMenuCurCardItem:: ; d67e
 	ds $2
 
-wd680:: ; d680
+wGRIslandScrollConfig:: ; d680
 	ds $1
 
 wOWScrollSpeed:: ; d681
@@ -2721,7 +2721,7 @@ wDebugDuelAnimLocationParam:: ; d688
 
 	ds $3
 
-wd68c:: ; d68c
+wSpriteAnimTemp:: ; d68c
 	ds $1
 
 ; represents a 16-bit value
@@ -2731,13 +2731,13 @@ wDecimalRepresentation:: ; d68d
 
 	ds $1
 
-wd693:: ; d693
+wGfxCacheFlags:: ; d693
 	ds $1
 
 wDecompressedBGMap:: ; d694
 	ds 2 * TILEMAP_WIDTH
 
-wd6d4:: ; d6d4
+wDecompressedTilemapPermissions:: ; d6d4
 	ds $100
 
 wBGMapAttribute:: ; d7d4
@@ -2752,7 +2752,7 @@ wBGMapWidth:: ; d7d6
 wBGMapHeight:: ; d7d7
 	ds $1
 
-wd7d8:: ; d7d8
+wOWPermissionsPtr:: ; d7d8
 	ds $1
 
 wd7d9:: ; d7d9
@@ -2760,16 +2760,16 @@ wd7d9:: ; d7d9
 
 	ds $2
 
-wd7dc:: ; d7dc
+wLoadedBGMapWidth:: ; d7dc
 	ds $1
 
-wd7dd:: ; d7dd
+wLoadedBGMapHeight:: ; d7dd
 	ds $1
 
-wd7de:: ; d7de
+wLoadedTilesetBank:: ; d7de
 	ds $1
 
-wd7df:: ; d7df
+wLoadedTilesetPtr:: ; d7df
 	ds $2
 
 wOWAnimBank:: ; d7e1
@@ -2780,16 +2780,16 @@ wOWAnimPtr:: ; d7e2
 
 	ds $1
 
-wd7e5:: ; d7e5
+wOWTileFrameGfxPtr:: ; d7e5
 	ds $2
 
-wd7e7:: ; d7e7
+wOWTileFrameGfxBank:: ; d7e7
 	ds $1
 
-wd7e8:: ; d7e8
+wOWScrollTargetX:: ; d7e8
 	ds $1
 
-wd7e9:: ; d7e9
+wOWScrollTargetY:: ; d7e9
 	ds $1
 
 	ds $2
@@ -2804,10 +2804,10 @@ wOWMap:: ; d7ec
 wOWAnimatedTiles:: ; d7ee
 	ds NUM_OW_ANIMATED_TILES * $4
 
-wd852:: ; d852
+wOWTilemapOverlayCount:: ; d852
 	ds $1
 
-wd853:: ; d853
+wOWTilemapOverlayBuffer:: ; d853
 	ds $40
 
 wScrollTargetSpritePtr:: ; d893
@@ -2816,16 +2816,16 @@ wScrollTargetSpritePtr:: ; d893
 wOWScrollState:: ; d895
 	ds $1
 
-wd896:: ; d896
+wPalAnimTarget:: ; d896
 	ds $2
 
-wd898:: ; d898
+wPalAnimFrameDelay:: ; d898
 	ds $1
 
-wd899:: ; d899
+wPalAnimFrameCounter:: ; d899
 	ds $1
 
-wd89a:: ; d89a
+wPalAnimFrameIndex:: ; d89a
 	ds $1
 
 wOWScrollX:: ; d89b
@@ -2836,10 +2836,10 @@ wOWScrollY:: ; d89c
 
 wOWDataEnd::
 
-wd89d:: ; d89d
+wBGBoxFillTile:: ; d89d
 	ds $1
 
-wd89e:: ; d89e
+wBGBoxFillAttr:: ; d89e
 	ds $1
 
 wPauseMenuCursorPosition:: ; d89f
@@ -2849,7 +2849,7 @@ wPauseMenuCursorPosition:: ; d89f
 wPauseMenuWithChips:: ; d8a0
 	ds $1
 
-wd8a1:: ; d8a1
+wOWNPCMovementMode:: ; d8a1
 	ds $1
 
 wSpriteAnimationStructs:: ; d8a2
@@ -2878,26 +2878,26 @@ wd96c:: ; d96c
 wd96d:: ; d96d
 	ds $2
 
-wd96f:: ; d96f
+wSpriteAnimRenderFlags:: ; d96f
 	ds $1
 
-wd970:: ; d970
+wSpriteAnimCoordFlags:: ; d970
 	ds $1
 
-wd971:: ; d971
+wSpriteAnimFrameXOffset:: ; d971
 	ds $1
 
-wd972:: ; d972
+wSpriteAnimFrameYOffset:: ; d972
 	ds $1
 
 	ds $2
 
-wd975:: ; d975
+wSpriteAnimFrameTileOffset:: ; d975
 	ds $1
 
 wCurSpriteAnim:: sprite_anim_struct wCurSpriteAnim ; d976
 
-wd986:: ; d986
+wNPCBoundaryOverride:: ; d986
 	ds $1
 
 ; NPC_* ID (or NPC_NONE)
@@ -2908,13 +2908,13 @@ wTempScriptNPC:: ; d987
 	ds $1
 
 ; NPC_* ID
-wd989:: ; d989
+wNPCStepNPCID:: ; d989
 	ds $1
 
-wd98a:: ; d98a
+wNPCStepResult:: ; d98a
 	ds $1
 
-wd98b:: ; d98b
+wNPCStateBuffer:: ; d98b
 	ds 5 * MAX_NUM_OW_OBJECTS
 
 wFrameFunctionStackSize:: ; d9bd
@@ -2960,7 +2960,7 @@ wPCMenuCursorPosition:: ; d9dc
 wPaletteFadeMode:: ; d9dd
 	ds $1
 
-wd9de:: ; d9de
+wPalFadeStepStatus:: ; d9de
 	ds $1
 
 ; whether pal fading happens
@@ -3064,18 +3064,18 @@ ENDR
 
 	ds $2
 
-wda8b:: ; da8b
+wNPCStepAmount:: ; da8b
 	ds $1
 
-wda8c:: ; da8c
+wLoadOWObjectNPCID:: ; da8c
 	ds $1
 
-wda8d:: ; da8d
+wLoadOWObjectDirection:: ; da8d
 	ds $1
 
 	ds $6
 
-wda94:: ; da94
+wLoadOWObjectTilePos:: ; da94
 	ds $2
 
 	ds $1
@@ -3084,7 +3084,7 @@ wScrollTargetObject:: ; da97
 	ds $1
 
 ; set to FF while chip count window is on screen (top-left corner)
-wda98:: ; da98
+wChipCountWindowVisible:: ; da98
 	ds $1
 
 ; capped at MAX_CHIPS
@@ -3115,22 +3115,22 @@ wTitleScreenCards:: ; daa9
 
 	ds $4
 
-wdabd:: ; dabd
+wTitleAnimSCXUpper:: ; dabd
 	ds $1
 
 	ds $1
 
-wdabf:: ; dabf
+wTitleAnimSCXMiddle:: ; dabf
 	ds $1
 
 	ds $1
 
-wdac1:: ; dac1
+wIntroLineSCXBuffer:: ; dac1
 	ds $20
 
 	ds $1c
 
-wdafd:: ; dafd
+wIntroDistortionCounter:: ; dafd
 	ds $1
 
 	ds $1
@@ -3303,16 +3303,16 @@ wTempBackgroundPalettesCGB:: ; dc10
 
 	ds $7
 
-wdc57:: ; dc57
+wDuelAnimFrameFuncActive:: ; dc57
 	ds $1
 
-wdc58:: ; dc58
+wDuelAnimSpriteStartDelay:: ; dc58
 	ds $1
 
 wNumActiveAnimations:: ; dc59
 	ds $1
 
-wdc5a:: ; dc5a
+wDuelAnimDispatchID:: ; dc5a
 	ds $1
 
 	ds $1
@@ -3348,10 +3348,10 @@ wDuelAnimBuffer:: ; dc60
 	duel_anim_struct wDuelAnim16
 wDuelAnimBufferEnd::
 
-wdce0:: ; dce0
+wAnimPlayerCoin:: ; dce0
 	ds $1
 
-wdce1:: ; dce1
+wAnimOppCoin:: ; dce1
 	ds $1
 
 ; holds an animation to play
@@ -3402,10 +3402,10 @@ wScreenAnimUpdatePtr:: ; dceb
 wScreenAnimDuration:: ; dced
 	ds $1
 
-wdcee:: ; dcee
+wShakeOffsetTablePtr:: ; dcee
 	ds $2
 
-wdcf0:: ; dcf0
+wDuelAnimCallbackActive:: ; dcf0
 	ds $1
 
 wAnimationTileset:: ; dcf1
@@ -3482,25 +3482,25 @@ wGrandMasterCupBracketChampionSpriteAnimIndex:: ; dd23
 wGrandMasterCupBracketChampionSpriteAnimTick:: ; dd24
 	ds $1
 
-wdd25:: ; dd25
+wCreateSpriteAnimGfxPtr:: ; dd25
 	ds $2
 
-wdd27:: ; dd27
+wCreateSpriteAnimAnimID:: ; dd27
 	ds $2
 
-wdd29:: ; dd29
+wCreateSpriteAnimFramesetID:: ; dd29
 	ds $2
 
-wdd2b:: ; dd2b
+wCreateSpriteAnimPalPtr:: ; dd2b
 	ds $2
 
-wdd2d:: ; dd2d
+wCreateSpriteAnimIndex:: ; dd2d
 	ds $1
 
-wdd2e:: ; dd2e
+wCreateSpriteAnimPalIndex:: ; dd2e
 	ds $1
 
-wdd2f:: ; dd2f
+wLoadBGGraphicsStartPal:: ; dd2f
 	ds $1
 
 ; id of the mail item being read
@@ -3567,13 +3567,13 @@ wBlackBoxCardReceived:: ; dd5f
 wBillsPCCardReceived:: ; dd73
 	ds $2
 
-wdd75:: ; dd75
+wScreenShakeType:: ; dd75
 	ds $1
 
-wdd76:: ; dd76
+wScreenShakeIndex:: ; dd76
 	ds $1
 
-wdd77:: ; dd77
+wScreenShakeRepeatCount:: ; dd77
 	ds $1
 
 wGrandMasterCupPrizeSelectionMenuCursorPosition:: ; dd78
@@ -3603,13 +3603,13 @@ wCardDungeonIsPlayable:: ; dd93
 wCardTilemap:: ; dd94
 	ds $30
 
-wddc4:: ; ddc4
+wCardAttrMapBuffer:: ; ddc4
 	ds $30
 
 wCardTilemapOffset:: ; ddf4
 	ds $1
 
-wddf5:: ; ddf5
+wCardAttrMapOffset:: ; ddf5
 	ds $1
 
 ; TCG_ISLAND or GR_ISLAND
@@ -3672,19 +3672,19 @@ wCreditsCmdArg4:: ; de4c
 wCreditsCmdArg5:: ; de4d
 	ds $1
 
-wde4e:: ; de4e
+wCreditsScrollXPos:: ; de4e
 	ds $1
 
-wde4f:: ; de4f
+wCreditsScrollYPos:: ; de4f
 	ds $1
 
-wde50:: ; de50
+wCreditsScrollXTarget:: ; de50
 	ds $1
 
-wde51:: ; de51
+wCreditsScrollYTarget:: ; de51
 	ds $1
 
-wde52:: ; de52
+wCreditsScrollSpeed:: ; de52
 	ds $1
 
 wProloguePortraitScene:: ; de53
@@ -3693,7 +3693,7 @@ wProloguePortraitScene:: ; de53
 wPlayerName:: ; de54
 	ds NAME_BUFFER_LENGTH
 
-wde64:: ; de64
+wPlayerGenderMenuCursor:: ; de64
 	ds $1
 
 ; used by GetNextBackgroundScroll
@@ -3710,7 +3710,7 @@ wNextScrollLY:: ; de67
 
 	ds $1
 
-wde69:: ; de69
+wCallbackPointer:: ; de69
 	ds $2
 
 SECTION "WRAM2", WRAMX
@@ -3806,7 +3806,7 @@ wCurSfxBank:: ; d007
 wMusicStereoPanning:: ; d008
 	ds $1
 
-wdd85:: ; d009
+wSFXStereoPanning:: ; d009
 	ds $1
 
 wMusicDuty1:: ; d00a
@@ -3823,7 +3823,7 @@ wMusicWave:: ; d00e
 wMusicWaveChange:: ; d00f
 	ds $1
 
-wdd8c:: ; d010
+wSFXChannelMask:: ; d010
 	ds $1
 
 wAudio_d011:: ; d011
@@ -3861,10 +3861,10 @@ wMusicCh3CurPitch:: ; d02e
 wMusicCh3CurOctave:: ; d02f
 	ds $1
 
-wddab:: ; d030
+wMusicNoiseLenBuffer:: ; d030
 	ds $1
 
-wddac:: ; d031
+wMusicNoiseEnvBuffer:: ; d031
 	ds $1
 
 	ds $2
@@ -3872,29 +3872,29 @@ wddac:: ; d031
 wMusicOctave:: ; d034
 	ds $4
 
-wddb3:: ; d038
+wMusicChannelRestartFlag:: ; d038
 	ds $4
 
-wddb7:: ; d03c
+wMusicCh1CutoffEnable:: ; d03c
 	ds $1
 
-wddb8:: ; d03d
+wMusicCh2CutoffEnable:: ; d03d
 	ds $1
 
-wddb9:: ; d03e
+wMusicCh3CutoffEnable:: ; d03e
 	ds $1
 
-wddba:: ; d03f
+wMusicCh4CutoffEnable:: ; d03f
 	ds $1
 
-wddbb:: ; d040
+wMusicNoteDuration:: ; d040
 	ds $4
 
 ; the delay (1-8) before a note is cut off early (0 is disabled)
 wMusicCutoff:: ; d044
 	ds $4
 
-wddc3:: ; d048
+wMusicCutoffCountdown:: ; d048
 	ds $4
 
 ; the volume to apply after a cutoff
@@ -3914,13 +3914,13 @@ wMusicVibratoType:: ; d058
 wMusicVibratoType2:: ; d05c
 	ds $4
 
-wdddb:: ; d060
+wMusicVibratoPhase:: ; d060
 	ds $4
 
 wMusicVibratoDelay:: ; d064
 	ds $4
 
-wdde3:: ; d068
+wMusicVibratoCounter:: ; d068
 	ds $4
 
 wAudio_d06c:: ; d06c
@@ -3948,22 +3948,22 @@ wAudio_d080:: ; d080
 wAudio_d083:: ; d083
 	ds $1
 
-wdded:: ; d084
+wMusicNoiseCurDataPtr:: ; d084
 	ds $2
 
-wddef:: ; d086
+wMusicNoiseActive:: ; d086
 	ds $1
 
 wAudio_d087:: ; d087
 	ds $1
 
-wddf0:: ; d088
+wMusicChannelMuteMask:: ; d088
 	ds $1
 
 wMusicPanning:: ; d089
 	ds $1
 
-wddf2:: ; d08a
+wMusicForceResetFlag:: ; d08a
 	ds $1
 
 ; 4 pointers to the positions on the stack for each channel
@@ -3982,40 +3982,40 @@ wMusicCh3Stack:: ; d0ab
 wMusicCh4Stack:: ; d0b7
 	ds $c
 
-wde2b:: ; d0c3
+wSFXChannelRestartPending:: ; d0c3
 	ds $3
 
-wde2e:: ; d0c6
+wSFXNoiseRestartPending:: ; d0c6
 	ds $1
 
-wde2f:: ; d0c7
+wSFXChannelPitchOffset:: ; d0c7
 	ds $3
 
-wde32:: ; d0ca
+wSFXNoisePitchOffset:: ; d0ca
 	ds $1
 
-wde33:: ; d0cb
+wSFXChannelFrameDelay:: ; d0cb
 	ds $4
 
-wde37:: ; d0cf
+wSFXChannelFrequency:: ; d0cf
 	ds $6
 
-wde3d:: ; d0d5
+wSFXNoiseFrequency:: ; d0d5
 	ds $2
 
-wde3f:: ; d0d7
+wSFXChannelLoopCount:: ; d0d7
 	ds $4
 
-wde43:: ; d0db
+wSFXChannelLoopPtr:: ; d0db
 	ds $8
 
-wd0e3:: ; d0e3
+wSFXChannelPointers:: ; d0e3
 	ds $8
 
-wde53:: ; d0eb
+wSFXIsPlaying:: ; d0eb
 	ds $1
 
-wde54:: ; d0ec
+wSFXChannelLoadMask:: ; d0ec
 	ds $1
 
 wAudio_d0ed:: ; d0ed
@@ -4051,28 +4051,28 @@ wMusicChannelPointersBackup:: ; d0ff
 wMusicMainLoopStartBackup:: ; d107
 	ds $8
 
-wde76:: ; d10f
+wMusicNoiseLenBufferBackup:: ; d10f
 	ds $1
 
-wde77:: ; d110
+wMusicNoiseEnvBufferBackup:: ; d110
 	ds $1
 
 wMusicOctaveBackup:: ; d111
 	ds $4
 
-wde7c:: ; d115
+wMusicChannelRestartFlagBackup:: ; d115
 	ds $4
 
-wde80:: ; d119
+wMusicCutoffEnableBackup:: ; d119
 	ds $4
 
-wde84:: ; d11d
+wMusicNoteDurationBackup:: ; d11d
 	ds $4
 
 wMusicCutoffBackup:: ; d121
 	ds $4
 
-wde8c:: ; d125
+wMusicCutoffCountdownBackup:: ; d125
 	ds $4
 
 wMusicEchoBackup:: ; d129
@@ -4096,10 +4096,10 @@ wMusicVolumeBackup:: ; d13d
 wMusicFrequencyOffsetBackup:: ; d140
 	ds $3
 
-wdeaa:: ; d143
+wMusicNoiseCurDataPtrBackup:: ; d143
 	ds $2
 
-wdeac:: ; d145
+wMusicNoiseActiveBackup:: ; d145
 	ds $1
 
 wAudio_d146:: ; d146


### PR DESCRIPTION
Rename generic wd-prefixed WRAM labels to descriptive names across the AI, duel, card UI, OW movement, sprite animation, audio, and SFX subsystems.