### PR TITLE
Disassemble multiline input handlers, config menu box params, and a few more in Bank 6 and 7

### DIFF
--- a/src/constants/name_constants.asm
+++ b/src/constants/name_constants.asm
@@ -13,6 +13,15 @@ DEF MAX_DECK_NAME_LENGTH        EQU 20 * 1 ; note that its unit is byte!
 
 DEF NAMING_SCREEN_BUFFER_LENGTH EQU 24
 
+DEF MAX_MULTILINE_INPUT_CHARS_PER_LINE   EQU 18
+DEF MAX_MULTILINE_INPUT_LENGTH_PER_LINE  EQU MAX_MULTILINE_INPUT_CHARS_PER_LINE * 2                          ; 36
+DEF MAX_MULTILINE_INPUT_LINES            EQU 2
+DEF MAX_MULTILINE_INPUT_CHARS            EQU MAX_MULTILINE_INPUT_CHARS_PER_LINE * MAX_MULTILINE_INPUT_LINES  ; 36
+DEF MAX_MULTILINE_INPUT_LENGTH           EQU MAX_MULTILINE_INPUT_LENGTH_PER_LINE * MAX_MULTILINE_INPUT_LINES ; 72
+
+DEF PER_LINE_INPUT_SCREEN_BUFFER_LENGTH  EQU MAX_MULTILINE_INPUT_LENGTH_PER_LINE + 2                         ; 38
+DEF MULTILINE_INPUT_SCREEN_BUFFER_LENGTH EQU MAX_MULTILINE_INPUT_LENGTH + 2                                  ; 74
+
 	const_def
 	const NAME_MODE_HIRAGANA  ; $0
 	const NAME_MODE_KATAKANA  ; $1
@@ -20,9 +29,14 @@ DEF NAMING_SCREEN_BUFFER_LENGTH EQU 24
 	const NAME_MODE_LOWER_ABC ; $3
 DEF NUM_NAME_MODES EQU const_value
 
+; keyboard toggle locations:
+; - hiragana mode: katakana, upper abc, lower abc, done
+; - katakana mode: hiragana, upper abc, lower abc, done
+; - upper abc mode: hiragana, katakana, lower abc, done
+; - lower abc mode: hiragana, katakana, upper abc, done
 	const_def $06
-	const KEYBOARD_UNKNOWN          ; $06
-	const KEYBOARD_TOGGLE_KATAKANA  ; $07
-	const KEYBOARD_TOGGLE_UPPER_ABC ; $08
-	const KEYBOARD_TOGGLE_LOWER_ABC ; $09
-	const KEYBOARD_DONE             ; $0a
+	const KEYBOARD_UNKNOWN  ; $06
+	const KEYBOARD_TOGGLE_1 ; $07
+	const KEYBOARD_TOGGLE_2 ; $08
+	const KEYBOARD_TOGGLE_3 ; $09
+	const KEYBOARD_DONE     ; $0a

--- a/src/engine/bank06.asm
+++ b/src/engine/bank06.asm
@@ -5537,7 +5537,7 @@ LoadHandCardsIcon:
 	ld hl, HandCardsGfx
 	ld de, v0Tiles2 + $38 tiles
 	ld b, 4 tiles
-	call Func_1b8f1
+	call CopyBBytesFromHLToDE_Bank06
 	ret
 
 HandCardsGfx:
@@ -5606,8 +5606,8 @@ InputName:
 	call InitializeInputName
 	call Set_OBJ_8x8
 
-	xor a
-	ld [wd3ef], a
+	xor a ; FALSE
+	ld [wIsMultilineInput], a
 	ld [wTileMapFill], a
 	call EmptyScreen
 	call ZeroObjectPositions
@@ -5882,7 +5882,7 @@ ProcessTextWithUnderbar:
 	ret
 
 .underbar_chars
-	db $57
+	db $57 ; "_"
 	textfw "__________"
 	done
 
@@ -6093,11 +6093,11 @@ DrawSymbolAtCharPosition:
 	call GetCharInfoFromPos
 	ld a, [hli] ; y
 	ld c, a
-	ld a, [wd3ef]
+	ld a, [wIsMultilineInput]
 	or a
-	jr z, .asm_1b1ae
+	jr z, .got_y
 	inc c
-.asm_1b1ae
+.got_y
 	ld b, [hl] ; x
 	dec b
 	ld a, e ; tile
@@ -6123,9 +6123,9 @@ UpdateNameTextCursor:
 	ld a, [wMenuInvisibleCursorTile]
 	cp b
 	jr z, .done ; cursor is invisible, done
-	ld a, [wd3ef]
+	ld a, [wIsMultilineInput]
 	or a
-	jr nz, .asm_1b201
+	jr nz, .check_multiline
 
 ; place text cursor on the next name character position
 	ld a, [wNamingScreenBufferLength]
@@ -6158,21 +6158,21 @@ UpdateNameTextCursor:
 	pop af
 	ret
 
-.asm_1b201
+.check_multiline
 	ld a, [wNamingScreenBufferLength]
-	sub $24
-	jr c, .asm_1b212
-	cp $24
-	jr nz, .asm_1b20e
+	sub MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	jr c, .fallback_single_line
+	cp MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	jr nz, .got_line_2_length
 	dec a
 	dec a
-.asm_1b20e
+.got_line_2_length
 	ld e, 32 ; y
-	jr .asm_1b217
-.asm_1b212
+	jr .got_y
+.fallback_single_line
 	ld a, [wNamingScreenBufferLength]
 	ld e, 24 ; y
-.asm_1b217
+.got_y
 	sra a
 	ld l, a
 	ld h, 8
@@ -6220,37 +6220,45 @@ SelectKeyboardItem:
 	ld d, a
 	cp KEYBOARD_DONE
 	jp z, .set_carry
-	cp KEYBOARD_TOGGLE_KATAKANA
-	jr nz, .asm_1b276
+
+; toggle 1
+	cp KEYBOARD_TOGGLE_1
+	jr nz, .check_toggle_2
 	ld a, [wNamingScreenMode]
 	or a
-	jr nz, .hiragana_mode
+	jr nz, .to_hiragana_mode
+; to katakana mode
 	ld a, NAME_MODE_KATAKANA
 	jp .set_mode
-.hiragana_mode
+.to_hiragana_mode
 	xor a ; NAME_MODE_HIRAGANA
 	jp .set_mode
-.asm_1b276
-	cp KEYBOARD_TOGGLE_UPPER_ABC
-	jr nz, .asm_1b289
+
+.check_toggle_2
+	cp KEYBOARD_TOGGLE_2
+	jr nz, .check_toggle_3
 	ld a, [wNamingScreenMode]
 	cp NAME_MODE_UPPER_ABC
-	jr c, .not_upper_abc_mode
+	jr c, .to_upper_abc_mode
+; to katakana mode
 	ld a, NAME_MODE_KATAKANA
 	jr .set_mode
-.not_upper_abc_mode
+.to_upper_abc_mode
 	ld a, NAME_MODE_UPPER_ABC
 	jr .set_mode
-.asm_1b289
-	cp KEYBOARD_TOGGLE_LOWER_ABC
+
+.check_toggle_3
+	cp KEYBOARD_TOGGLE_3
 	jr nz, .character_item
 	ld a, [wNamingScreenMode]
 	cp NAME_MODE_LOWER_ABC
-	jr nz, .not_lower_abc_mode
+	jr nz, .to_lower_abc_mode
+; to upper abc mode
 	ld a, NAME_MODE_UPPER_ABC
 	jr .set_mode
-.not_lower_abc_mode
+.to_lower_abc_mode
 	ld a, NAME_MODE_LOWER_ABC
+
 .set_mode
 	ld [wNamingScreenMode], a
 	call UpdateNamingScreenUI
@@ -6278,6 +6286,7 @@ SelectKeyboardItem:
 	pop hl
 	jr c, .no_carry
 	jr .apply_diacritic
+
 .check_handakuten
 	ldfw bc, "゜"
 	ld a, d
@@ -6291,14 +6300,14 @@ SelectKeyboardItem:
 	call GetDiacriticCharacter
 	pop hl
 	jr c, .no_carry
+
 .apply_diacritic
-	; decrease length by 2
+; decrease length by 2
 	ld a, [wNamingScreenBufferLength]
 	dec a
 	dec a
 	ld [wNamingScreenBufferLength], a
-
-	; get pointer to last character in buffer
+; get pointer to last character in buffer
 	ld hl, wNamingScreenBuffer
 	push de
 	ld d, $00
@@ -6314,12 +6323,12 @@ SelectKeyboardItem:
 	jr nz, .add_character
 	ld a, [wNamingScreenMode]
 	or a
-	jr nz, .asm_1b2fb
-	; NAME_MODE_HIRAGANA
+	jr nz, .katakana
+; NAME_MODE_HIRAGANA
 	ld a, TX_HIRAGANA
 	jr .add_character
-.asm_1b2fb
-	; NAME_MODE_KATAKANA
+.katakana
+; NAME_MODE_KATAKANA
 	ld a, TX_KATAKANA
 	jr .add_character
 .lower_abc
@@ -6345,11 +6354,11 @@ SelectKeyboardItem:
 	cp [hl]
 	pop hl
 	jr nz, .not_last_character
-	; overwrite last character
+; overwrite last character
 	ld hl, wNamingScreenBuffer
 	dec hl
 	dec hl
-	; hl = wNamingScreenBuffer - 2
+; hl = wNamingScreenBuffer - 2
 	jr .got_char_position
 .not_last_character
 	inc [hl]
@@ -6364,11 +6373,12 @@ SelectKeyboardItem:
 	inc hl
 	ld [hl], TX_END
 	call ProcessTextWithUnderbar
+
 .no_carry
 	or a
 	ret
 
-.set_carry:
+.set_carry
 	scf
 	ret
 
@@ -6493,7 +6503,7 @@ KeyboardData:
 	kbchar 10,  2, "え", "?", "@"
 	kbchar 12,  2, "お", "4", ":"
 	kbchar 14,  2, "ゃ", "ぃ", "<LIGHTNING>"
-	kbitem 16,  2, KEYBOARD_TOGGLE_KATAKANA, 3, 2
+	kbitem 16,  2, KEYBOARD_TOGGLE_1, 3, 2
 
 	; col 1
 	kbchar  4,  4, "か", "B", "b"
@@ -6502,7 +6512,7 @@ KeyboardData:
 	kbchar 10,  4, "け", "&", "&"
 	kbchar 12,  4, "こ", "5", ";"
 	kbchar 14,  4, "ゅ", "ぅ", "<GRASS>"
-	kbitem 16,  2, KEYBOARD_TOGGLE_KATAKANA, 2, 2
+	kbitem 16,  2, KEYBOARD_TOGGLE_1, 2, 2
 
 	; col 2
 	kbchar  4,  6, "さ", "C", "c"
@@ -6511,7 +6521,7 @@ KeyboardData:
 	kbchar 10,  6, "せ", "+", "/"
 	kbchar 12,  6, "そ", "6", "_"
 	kbchar 14,  6, "ょ", "ぇ", "<FIRE>"
-	kbitem 16,  2, KEYBOARD_TOGGLE_KATAKANA, 2, 3
+	kbitem 16,  2, KEYBOARD_TOGGLE_1, 2, 3
 
 	; col 3
 	kbchar  4,  8, "た", "D", "d"
@@ -6520,7 +6530,7 @@ KeyboardData:
 	kbchar 10,  8, "て", "-", "*"
 	kbchar 12,  8, "と", "7", "<"
 	kbchar 14,  8, "っ", "ぉ", "<WATER>"
-	kbitem 16,  7, KEYBOARD_TOGGLE_UPPER_ABC, 2, 3
+	kbitem 16,  7, KEYBOARD_TOGGLE_2, 2, 3
 
 	; col 4
 	kbchar  4, 10, "な", "E", "e"
@@ -6529,7 +6539,7 @@ KeyboardData:
 	kbchar 10, 10, "ね", "・", "+"
 	kbchar 12, 10, "の", "8", ">"
 	kbchar 14, 10, "を", "ァ", "<PSYCHIC>"
-	kbitem 16,  7, KEYBOARD_TOGGLE_UPPER_ABC, 2, 2
+	kbitem 16,  7, KEYBOARD_TOGGLE_2, 2, 2
 
 	; col 5
 	kbchar  4, 12, "は", "F", "f"
@@ -6538,7 +6548,7 @@ KeyboardData:
 	kbchar 10, 12, "へ", "0", "-"
 	kbchar 12, 12, "ほ", "9", " "
 	kbchar 14, 12, "゛", "ィ", "<FIGHTING>"
-	kbitem 16, 12, KEYBOARD_TOGGLE_LOWER_ABC, 2, 2
+	kbitem 16, 12, KEYBOARD_TOGGLE_3, 2, 2
 
 	; col 6
 	kbchar  4, 14, "ま", "G", "g"
@@ -6547,7 +6557,7 @@ KeyboardData:
 	kbchar 10, 14, "め", "1", "="
 	kbchar 12, 14, "も", "<No>", " "
 	kbchar 14, 14, "゜", "ゥ", "<COLORLESS>"
-	kbitem 16, 12, KEYBOARD_TOGGLE_LOWER_ABC, 2, 2
+	kbitem 16, 12, KEYBOARD_TOGGLE_3, 2, 2
 
 	; col 7
 	kbchar  4, 16, "や", "H", "h"
@@ -6616,18 +6626,477 @@ HandakutenTable:
 	diacritic "べ", "ぺ" ; katakana ベ, ペ
 	diacritic "ぼ", "ぽ" ; katakana ボ, ポ
 	dw 0 ; end
-; 0x1b613
 
-SECTION "Bank 6@78f1", ROMX[$78f1], BANK[$6]
+InitInputMultilineText:
+	ld a, MAX_MULTILINE_INPUT_LENGTH
+	ld [wNamingScreenBufferMaxLength], a
+	ld a, MULTILINE_INPUT_SCREEN_BUFFER_LENGTH
+	ld hl, wNamingScreenBuffer
+	farcall ClearNBytesFromHL
+	xor a
+	ld [wNamingScreenBufferLength], a
+	ret
 
-Func_1b8f1:
+InputMultilineText:
+	call InitInputMultilineText
+	call Set_OBJ_8x8
+
+	xor a
+	ld [wTileMapFill], a
+	call EmptyScreen
+	call ZeroObjectPositions
+	ld a, TRUE
+	ld [wIsMultilineInput], a
+	ld [wVBlankOAMCopyToggle], a
+	call LoadSymbolsFont
+	lb de, $38, $bf
+	call SetupText
+	call LoadFullWidthTextCursorTile
+	xor a ; NAME_MODE_HIRAGANA
+	ld [wNamingScreenMode], a
+
+	call UpdateMultilineInputScreenUI
+
+	xor a
+	ld [wNamingScreenCursorX], a
+	ld [wNamingScreenCursorY], a
+
+	ld a, 9
+	ld [wNamingScreenNumColumns], a
+	ld a, 7
+	ld [wNumMenuItems], a
+	ld a, SYM_CURSOR_R
+	ld [wMenuVisibleCursorTile], a
+	ld a, SYM_SPACE
+	ld [wMenuInvisibleCursorTile], a
+
+.loop
+	ld a, TRUE
+	ld [wVBlankOAMCopyToggle], a
+	call DoFrame
+
+	ldh a, [hDPadHeld]
+	and PAD_START
+	jr z, .check_select
+	ld a, MENU_CONFIRM
+	call PlaySFXConfirmOrCancel_Bank06
+	call HideCursorAtCharPosition
+	ld a, 6
+	ld [wNamingScreenCursorY], a
+	inc a ; 7
+	ld [wNamingScreenCursorX], a
+	call ShowCursorAtCharPosition
+	jr .loop
+
+.check_select
+	ldh a, [hDPadHeld]
+	and PAD_SELECT
+	jr z, .handle_input
+	ld a, MENU_CONFIRM
+	call PlaySFXConfirmOrCancel_Bank06
+	ld a, [wNamingScreenMode]
+	inc a
+	cp NUM_NAME_MODES
+	jr c, .got_mode
+	xor a ; NAME_MODE_HIRAGANA
+.got_mode
+	ld [wNamingScreenMode], a
+	ld a, MENU_CONFIRM
+	call PlaySFXConfirmOrCancel_Bank06
+	call HideCursorAtCharPosition
+	xor a
+	ld [wNamingScreenCursorX], a
+	ld [wNamingScreenCursorY], a
+	call UpdateMultilineInputScreenUI
+	jr .loop
+
+.handle_input
+	call HandleNamingScreenInput
+	jr nc, .loop
+	cp $ff
+	jr z, .remove_last_char
+	call SelectKeyboardItem_Multiline
+	jr nc, .loop
+	call FinalizeInputName
+	ret
+
+.remove_last_char
+	ld a, [wNamingScreenBufferLength]
+	or a
+	jr z, .loop
+	ld e, a
+	ld d, $00
+	ld hl, wNamingScreenBuffer
+	add hl, de
+	dec hl
+	dec hl
+	ld [hl], TX_END
+	ld hl, wNamingScreenBufferLength
+	dec [hl]
+	dec [hl]
+	call ProcessMultilineInputWithUnderbar
+	jr .loop
+
+; stray ret
+	ret
+
+WriteBBytesToDE_Bank06:
+	push hl
+	ld l, e
+	ld h, d
+.loop_write
+	ld [hli], a
+	dec b
+	jr nz, .loop_write
+	pop hl
+	ret
+
+; fill row at y = c with $1c in v0BGMap0 and $04 in v1BGMap1 (CGB)
+Func_1b6f2:
+	ld b, 0 ; x
+	ld a, $1c
+	call BCCoordToBGMap0Address
+	ld b, SCREEN_WIDTH
+	call WriteBBytesToDE_Bank06
+	ld a, [wConsole]
+	cp CONSOLE_CGB
+	ret nz ; not cgb
+	ld a, $04
+	ld b, SCREEN_WIDTH
+	call BankswitchVRAM1
+	call WriteBBytesToDE_Bank06
+	call BankswitchVRAM0
+	ret
+
+UpdateMultilineInputScreenUI:
+	ld c, 4 ; y
+	call Func_1b6f2
+	call ProcessMultilineInputWithUnderbar
+	ld hl, .end_text
+	call PlaceTextItems
+
+	ld a, [wNamingScreenMode]
+	or a
+	jr nz, .not_hiragana
+; NAME_MODE_HIRAGANA
+	ld hl, .switches_from_hiragana
+	call PlaceTextItems
+	ldtx hl, HiraganaKeyboardText
+	jr .process
+
+.not_hiragana
+	dec a
+	jr nz, .not_katakana
+; NAME_MODE_KATAKANA
+	ld hl, .switches_from_katakana
+	call PlaceTextItems
+	ldtx hl, KatakanaKeyboardText
+	jr .process
+
+.not_katakana
+	dec a
+	jr nz, .lower_abc
+; NAME_MODE_UPPER_ABC
+	ld hl, .switches_from_uppercase
+	call PlaceTextItems
+	ldtx hl, UppercaseKeyboardText
+	jr .process
+
+.lower_abc
+; NAME_MODE_LOWER_ABC
+	ld hl, .switches_from_lowercase
+	call PlaceTextItems
+	ldtx hl, LowercaseKeyboardText
+
+.process
+	lb de, 2, 5
+	call InitTextPrinting
+	call ProcessTextFromID
+	call EnableLCD
+	ret
+
+.end_text
+	textitem 16, 17, EndText
+	textitems_end
+
+.switches_from_hiragana
+	textitem  2, 17, KatakanaOptionText
+	textitem  7, 17, UppercaseOptionText
+	textitem 12, 17, LowercaseOptionText
+	textitems_end
+
+.switches_from_katakana
+	textitem  2, 17, HiraganaOptionText
+	textitem  7, 17, UppercaseOptionText
+	textitem 12, 17, LowercaseOptionText
+	textitems_end
+
+.switches_from_uppercase
+	textitem  2, 17, HiraganaOptionText
+	textitem  7, 17, KatakanaOptionText
+	textitem 12, 17, LowercaseOptionText
+	textitems_end
+
+.switches_from_lowercase
+	textitem  2, 17, HiraganaOptionText
+	textitem  7, 17, KatakanaOptionText
+	textitem 12, 17, UppercaseOptionText
+	textitems_end
+
+
+SelectKeyboardItem_Multiline:
+	ld a, [wNamingScreenCursorX]
+	ld h, a
+	ld a, [wNamingScreenCursorY]
+	ld l, a
+	call GetCharInfoFromPos
+	inc hl
+	inc hl
+	ld e, [hl]
+	inc hl
+	ld a, [hli]
+	ld d, a
+	cp KEYBOARD_DONE
+	jp z, .set_carry
+
+; toggle 1
+	cp KEYBOARD_TOGGLE_1
+	jr nz, .check_toggle_2
+	ld a, [wNamingScreenMode]
+	or a
+	jr nz, .to_hiragana_mode
+; to katakana mode
+	ld a, NAME_MODE_KATAKANA
+	jp .set_mode
+.to_hiragana_mode
+	xor a ; NAME_MODE_HIRAGANA
+	jp .set_mode
+
+.check_toggle_2
+	cp KEYBOARD_TOGGLE_2
+	jr nz, .check_toggle_3
+	ld a, [wNamingScreenMode]
+	cp NAME_MODE_UPPER_ABC
+	jr c, .to_upper_abc_mode
+; to katakana mode
+	ld a, NAME_MODE_KATAKANA
+	jr .set_mode
+.to_upper_abc_mode
+	ld a, NAME_MODE_UPPER_ABC
+	jr .set_mode
+
+.check_toggle_3
+	cp KEYBOARD_TOGGLE_3
+	jr nz, .character_item
+	ld a, [wNamingScreenMode]
+	cp NAME_MODE_LOWER_ABC
+	jr nz, .to_lower_abc_mode
+; to upper abc mode
+	ld a, NAME_MODE_UPPER_ABC
+	jr .set_mode
+.to_lower_abc_mode
+	ld a, NAME_MODE_LOWER_ABC
+
+.set_mode
+	ld [wNamingScreenMode], a
+	call UpdateMultilineInputScreenUI
+	or a
+	ret
+
+.character_item
+	ld a, [wNamingScreenMode]
+	cp NAME_MODE_UPPER_ABC
+	jr z, .upper_abc
+	cp NAME_MODE_LOWER_ABC
+	jr z, .lower_abc
+
+; handle diacritics
+	ldfw bc, "゛"
+	ld a, d
+	cp b
+	jr nz, .check_handakuten
+	ld a, e
+	cp c
+	jr nz, .check_handakuten
+	push hl
+	ld hl, DakutenTable
+	call GetDiacriticCharacter
+	pop hl
+	jr c, .no_carry
+	jr .apply_diacritic
+
+.check_handakuten
+	ldfw bc, "゜"
+	ld a, d
+	cp b
+	jr nz, .not_diacritic
+	ld a, e
+	cp c
+	jr nz, .not_diacritic
+	push hl
+	ld hl, HandakutenTable
+	call GetDiacriticCharacter
+	pop hl
+	jr c, .no_carry
+
+.apply_diacritic
+; decrease length by 2
+	ld a, [wNamingScreenBufferLength]
+	dec a
+	dec a
+	ld [wNamingScreenBufferLength], a
+; get pointer to last character in buffer
+	ld hl, wNamingScreenBuffer
+	push de
+	ld d, $00
+	ld e, a
+	add hl, de
+	pop de
+	ld a, [hl]
+	jr .add_character
+
+.not_diacritic
+	ld a, d
+	or a
+	jr nz, .add_character
+	ld a, [wNamingScreenMode]
+	or a
+	jr nz, .katakana
+; NAME_MODE_HIRAGANA
+	ld a, TX_HIRAGANA
+	jr .add_character
+.katakana
+; NAME_MODE_KATAKANA
+	ld a, TX_KATAKANA
+	jr .add_character
+.lower_abc
+	inc hl
+	inc hl
+.upper_abc
+	ld e, [hl]
+	inc hl
+	ld a, [hl]
+	or a
+	jr nz, .add_character
+	ld a, TX_HIRAGANA
+
+; a = TX_* constant
+; e = character byte
+.add_character
+	ld d, a
+	ld hl, wNamingScreenBufferLength
+	ld a, [hl]
+	ld c, a
+	push hl
+	ld hl, wNamingScreenBufferMaxLength
+	cp [hl]
+	pop hl
+	jr nz, .not_last_character
+; overwrite last character
+	ld hl, wNamingScreenBuffer
+	dec hl
+	dec hl
+	jr .got_char_position
+.not_last_character
+	inc [hl]
+	inc [hl]
+	ld hl, wNamingScreenBuffer
+.got_char_position
+	ld b, $00
+	add hl, bc
+	ld [hl], d
+	inc hl
+	ld [hl], e
+	inc hl
+	ld [hl], TX_END
+	call ProcessMultilineInputWithUnderbar
+
+.no_carry
+	or a
+	ret
+
+.set_carry
+	scf
+	ret
+
+ProcessMultilineInputWithUnderbar:
+	ld a, [wNamingScreenBufferLength]
+	ld b, a
+	ld a, MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	sub b
+	jr nc, .line_1
+	xor a
+	ld b, MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+
+.line_1
+	push af
+	ld hl, wNamingScreenBuffer
+	ld de, wCurLineOfMultilineInput
+	call CopyBBytesFromHLToDE_Bank06
+	pop af
+	call .FillWithUnderbar
+	xor a ; TX_END
+	ld [wCurLineOfMultilineInput + MAX_MULTILINE_INPUT_LENGTH_PER_LINE], a
+	lb de, 1, 1
+	call InitTextPrinting
+	ld hl, wCurLineOfMultilineInput
+	call ProcessText
+
+; check line 2
+	ld a, [wNamingScreenBufferLength]
+	sub MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	jr nc, .line_2
+	ld a, MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	jr .process_text_with_underbar
+
+.line_2
+	ld b, a
+	ld a, MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	sub b
+	push af
+	ld hl, wNamingScreenBuffer + MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	ld de, wCurLineOfMultilineInput
+	call CopyBBytesFromHLToDE_Bank06
+	pop af
+
+.process_text_with_underbar
+	call .FillWithUnderbar
+	xor a ; TX_END
+	ld [wCurLineOfMultilineInput + MAX_MULTILINE_INPUT_LENGTH_PER_LINE], a
+	lb de, 1, 2
+	call InitTextPrinting
+	ld hl, wCurLineOfMultilineInput
+	call ProcessText
+
+.FillWithUnderbar
+	or a
+	ret z
+
+	ld c, a
+	ld a, MAX_MULTILINE_INPUT_LENGTH_PER_LINE
+	sub c
+	ld e, a
+	ld d, $00
+	ld hl, wCurLineOfMultilineInput
+	add hl, de
+.loop_fill
+	ld [hl], TX_FULLWIDTH4
+	inc hl
+	ld [hl], $57 ; "_"
+	inc hl
+	dec c
+	dec c
+	jr nz, .loop_fill
+	ret
+
+CopyBBytesFromHLToDE_Bank06:
 	ld a, b
 	or a
 	ret z
-.asm_1b8f4
+.loop
 	ld a, [hli]
 	ld [de], a
 	inc de
 	dec b
-	jr nz, .asm_1b8f4
+	jr nz, .loop
 	ret

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -325,9 +325,6 @@ GetDuelistPortrait::
 	db PORTRAIT_GR_X          ; GR_X_PIC
 	db PORTRAIT_TOBICHAN      ; TOBICHAN_PIC
 	db PORTRAIT_DR_MASON      ; DR_MASON_PIC
-; 0x1c116
-
-SECTION "Bank 7@416e", ROMX[$416e], BANK[$7]
 
 PauseMenuConfigScreen:
 	farcall Func_1022a

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -1455,9 +1455,15 @@ CheckPalFading::
 	ld a, [wPaletteFadeMode]
 	and a
 	ret
-; 0x1c941
 
-SECTION "Bank 7@494a", ROMX[$494a], BANK[$7]
+GetwD9DE:
+	ld a, [wd9de]
+	ret
+
+GetPalFadeDirection:
+	ld a, [wPalFadeDirection]
+	and a
+	ret
 
 ; fills the pals with fade enabled
 ; with color in a
@@ -1621,9 +1627,26 @@ StartFadeFromWhite:
 	pop bc
 	pop af
 	ret
-; 0x1ca09
 
-SECTION "Bank 7@4a21", ROMX[$4a21], BANK[$7]
+StartFadeToBlack:
+	push af
+	push bc
+	ld a, $01
+	ld b, $00
+	call StartPalFadeToBlackOrWhite
+	pop bc
+	pop af
+	ret
+
+StartFadeFromBlack:
+	push af
+	push bc
+	ld a, $01
+	ld b, $00
+	call StartPalFadeFromBlackOrWhite
+	pop bc
+	pop af
+	ret
 
 EnableBGPFading:
 	push hl
@@ -1631,9 +1654,13 @@ EnableBGPFading:
 	set 0, [hl]
 	pop hl
 	ret
-; 0x1ca29
 
-SECTION "Bank 7@4a31", ROMX[$4a31], BANK[$7]
+DisableBGPFading:
+	push hl
+	ld hl, wPaletteFadeFlags
+	res 0, [hl]
+	pop hl
+	ret
 
 EnableOBPFading:
 	push hl
@@ -1769,9 +1796,17 @@ SetAllOBPaletteFadeConfigsToEnabled:
 	jr c, .loop_pals
 	pop af
 	ret
-; 0x1cac3
 
-SECTION "Bank 7@4acf", ROMX[$4acf], BANK[$7]
+SetAllOBPaletteFadeConfigsToDisabled:
+	push af
+	xor a
+.loop_pals
+	call SetOBPaletteFadeConfigToDisabled
+	inc a
+	cp NUM_OBJECT_PALETTES
+	jr c, .loop_pals
+	pop af
+	ret
 
 HideNPCAnimsUnderMenuBox:
 	push af
@@ -4729,14 +4764,19 @@ GetwDuelAnimBufferSize:
 GetwDuelAnimBufferCurPos:
 	ld a, [wDuelAnimBufferCurPos]
 	ret
-; 0x1e411
 
-SECTION "Bank 7@6419", ROMX[$6419], BANK[$7]
+; set wAnimationsDisabled to TRUE
+DisableAnimations:
+	push af
+	ld a, TRUE
+	ld [wAnimationsDisabled], a
+	pop af
+	ret
 
-; sets wAnimationsDisabled to FALSE
+; set wAnimationsDisabled to FALSE
 EnableAnimations:
 	push af
-	xor a ; FALSe
+	xor a ; FALSE
 	ld [wAnimationsDisabled], a
 	pop af
 	ret

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -29,7 +29,7 @@ PrintNumber:
 	ld a, d
 	add c
 	ld d, a
-	ld hl, wDecimalRepresentation + $4
+	ld hl, wDecimalRepresentation + 4
 .loop_digits
 	ld a, [hld]
 	cp $ff
@@ -367,30 +367,30 @@ DrawConfigMenu:
 	lb de, 0, 12
 	lb bc, 20, 4
 	call DrawRegularTextBoxVRAM0
-	ld b, $07
-	ld hl, $44ee
+	ld b, BANK(ConfigExitMenuBoxParams)
+	ld hl, ConfigExitMenuBoxParams
 	lb de, 1, 17
 	call LoadMenuBoxParams
-	ld b, $07
-	ld hl, $4476
+	ld b, BANK(MessageSpeedSettingMenuBoxParams)
+	ld hl, MessageSpeedSettingMenuBoxParams
 	lb de, 6, 2
 	call LoadMenuBoxParams
 	ld a, [wMessageSpeedSetting]
 	call DrawMenuBox
-	ld b, $07
-	ld hl, $449a
+	ld b, BANK(DuelAnimationSettingMenuBoxParams)
+	ld hl, DuelAnimationSettingMenuBoxParams
 	lb de, 1, 6
 	call LoadMenuBoxParams
 	ld a, [wDuelAnimationsSetting]
 	call DrawMenuBox
-	ld b, $07
-	ld hl, $44b6
+	ld b, BANK(CoinTossAnimationSettingMenuBoxParams)
+	ld hl, CoinTossAnimationSettingMenuBoxParams
 	lb de, 1, 10
 	call LoadMenuBoxParams
 	ld a, [wCoinTossAnimationSetting]
 	call DrawMenuBox
-	ld b, $07
-	ld hl, $44ce
+	ld b, BANK(TextBoxFrameColorSettingMenuBoxParams)
+	ld hl, TextBoxFrameColorSettingMenuBoxParams
 	lb de, 1, 14
 	call LoadMenuBoxParams
 	ld a, [wTextBoxFrameColor]
@@ -509,8 +509,8 @@ HandleConfigMenu:
 	ret
 
 HandleMessageSpeedSettingMenuBox:
-	ld b, $07
-	ld hl, $4476
+	ld b, BANK(MessageSpeedSettingMenuBoxParams)
+	ld hl, MessageSpeedSettingMenuBoxParams
 	lb de, 6, 2
 	ld a, [wMessageSpeedSetting]
 	call LoadMenuBoxParams
@@ -522,8 +522,8 @@ HandleMessageSpeedSettingMenuBox:
 	ret
 
 HandleDuelAnimationsSettingMenuBox:
-	ld b, $07
-	ld hl, $449a
+	ld b, BANK(DuelAnimationSettingMenuBoxParams)
+	ld hl, DuelAnimationSettingMenuBoxParams
 	lb de, 1, 6
 	ld a, [wDuelAnimationsSetting]
 	call LoadMenuBoxParams
@@ -535,8 +535,8 @@ HandleDuelAnimationsSettingMenuBox:
 	ret
 
 HandleCoinTossAnimationSettingMenuBox:
-	ld b, $07
-	ld hl, $44b6
+	ld b, BANK(CoinTossAnimationSettingMenuBoxParams)
+	ld hl, CoinTossAnimationSettingMenuBoxParams
 	lb de, 1, 10
 	ld a, [wCoinTossAnimationSetting]
 	call LoadMenuBoxParams
@@ -548,8 +548,8 @@ HandleCoinTossAnimationSettingMenuBox:
 	ret
 
 HandleTextBoxFrameColorSettingMenuBox:
-	ld b, $07
-	ld hl, $44ce
+	ld b, BANK(TextBoxFrameColorSettingMenuBoxParams)
+	ld hl, TextBoxFrameColorSettingMenuBoxParams
 	lb de, 1, 14
 	ld a, [wTextBoxFrameColor]
 	call LoadMenuBoxParams
@@ -561,8 +561,8 @@ HandleTextBoxFrameColorSettingMenuBox:
 	ret
 
 HandleConfigExitMenuBox:
-	ld b, $07
-	ld hl, $44ee
+	ld b, BANK(ConfigExitMenuBoxParams)
+	ld hl, ConfigExitMenuBoxParams
 	lb de, 1, 17
 	xor a
 	call LoadMenuBoxParams
@@ -571,9 +571,22 @@ HandleConfigExitMenuBox:
 	xor a
 	call HandleMenuBox
 	ret
-; 0x1c379
 
-SECTION "Bank 7@4395", ROMX[$4395], BANK[$7]
+; dupe of _SaveAndApplyNewTextBoxFrameColor
+_SaveAndApplyNewTextBoxFrameColor_2::
+	ld a, [wTempTextBoxFrameColor_2]
+	ld b, a
+	call GetMenuBoxFocusedItem
+	cp b
+	ret z
+
+	ld [wTempTextBoxFrameColor_2], a
+	call EnableSRAM
+	ld [sTextBoxFrameColor], a
+	call DisableSRAM
+	bank1call SetDefaultPalettes
+	call FlushAllPalettes
+	ret
 
 LoadSavedOptions:
 	call EnableSRAM
@@ -700,9 +713,66 @@ ConvertTextSpeedToMessageSpeedSetting:
 .data
 	; values correspond to the 0,1,2,4,6 values just above
 	db 0, 1, 2, 0, 3, 0, 4
-; 0x1c45a
 
-SECTION "Bank 7@4502", ROMX[$4502], BANK[$7]
+_SaveAndApplyNewTextBoxFrameColor::
+	ld a, [wTempTextBoxFrameColor]
+	ld b, a
+	call GetMenuBoxFocusedItem
+	cp b
+	ret z
+
+	ld [wTempTextBoxFrameColor], a
+	call EnableSRAM
+	ld [sTextBoxFrameColor], a
+	call DisableSRAM
+	bank1call SetDefaultPalettes
+	call FlushAllPalettes
+	ret
+
+MessageSpeedSettingMenuBoxParams:
+	menubox_params FALSE, 10, 1, \
+		SYM_CURSOR_R, SYM_SPACE, SYM_CURSOR_R, SYM_CURSOR_R, \
+		NONE, PAD_B | PAD_UP | PAD_DOWN, TRUE, 0, NULL, NULL
+	textitem 0, 0, ConfigMessageSpeed1Text
+	textitem 2, 0, ConfigMessageSpeed2Text
+	textitem 4, 0, ConfigMessageSpeed3Text
+	textitem 6, 0, ConfigMessageSpeed4Text
+	textitem 8, 0, ConfigMessageSpeed5Text
+	textitems_end
+
+DuelAnimationSettingMenuBoxParams:
+	menubox_params FALSE, 18, 1, \
+		SYM_CURSOR_R, SYM_SPACE, SYM_CURSOR_R, SYM_CURSOR_R, \
+		NONE, PAD_B | PAD_UP | PAD_DOWN, TRUE, 0, NULL, NULL
+	textitem  1, 0, ConfigAnimationShowAllText
+	textitem  7, 0, ConfigAnimationSkipSomeText
+	textitem 15, 0, ConfigAnimationNoneText
+	textitems_end
+
+CoinTossAnimationSettingMenuBoxParams:
+	menubox_params FALSE, 18, 1, \
+		SYM_CURSOR_R, SYM_SPACE, SYM_CURSOR_R, SYM_CURSOR_R, \
+		NONE, PAD_B | PAD_UP | PAD_DOWN, TRUE, 0, NULL, NULL
+	textitem  1, 0, ConfigAnimationShowAllText
+	textitem 12, 0, ConfigAnimationSkipSomeText
+	textitems_end
+
+TextBoxFrameColorSettingMenuBoxParams:
+	menubox_params FALSE, 18, 1, \
+		SYM_CURSOR_R, SYM_SPACE, SYM_CURSOR_R, SYM_CURSOR_R, \
+		NONE, PAD_B | PAD_UP | PAD_DOWN, TRUE, 0, SaveAndApplyNewTextBoxFrameColor, NULL
+	textitem  1, 0, ConfigFrameColorRedText
+	textitem  6, 0, ConfigFrameColorBlueText
+	textitem 11, 0, ConfigFrameColorGreenText
+	textitem 16, 0, ConfigFrameColorBlackText
+	textitems_end
+
+ConfigExitMenuBoxParams:
+	menubox_params FALSE, 9, 1, \
+		SYM_CURSOR_R, SYM_SPACE, SYM_CURSOR_R, SYM_SPACE, \
+		PAD_A, PAD_B | PAD_UP | PAD_DOWN, FALSE, 0, NULL, NULL
+	textitem 1, 0, SingleSpaceText
+	textitems_end
 
 PauseMenuDiaryScreen:
 	farcall Func_1022a

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -5075,11 +5075,18 @@ Func_1e5a2::
 	call ShowSpecialRuleDescription
 .start_duel
 	bank1call StartDuel_VSAIOpp
+.exit
 	farcall Func_10252
 	ret
-; 0x1e5e5
 
-SECTION "Bank 7@65f8", ROMX[$65f8], BANK[$7]
+.Debug:
+	bank1call SetFontAndTextBoxFrameColor
+	call FlushAllPalettes
+	ldtx hl, DebugForceDuelWinPromptText
+	xor a
+	farcall DrawWideTextBox_PrintTextWithYesOrNoMenu
+	ld [wDuelResult], a
+	jr .exit
 
 RunDuelFromSRAM:
 	farcall Stub_10cfe

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -1456,7 +1456,7 @@ CheckPalFading::
 	and a
 	ret
 
-GetwD9DE:
+GetwD9DE::
 	ld a, [wd9de]
 	ret
 

--- a/src/engine/bank07.asm
+++ b/src/engine/bank07.asm
@@ -6220,9 +6220,31 @@ Func_1ed5e:
 .SceneNoNewMail
 	db SCENE_MAILBOX
 	tx MailboxNoNewMailText
-; 0x1ed7c
 
-SECTION "Bank 7@6da5", ROMX[$6da5], BANK[$7]
+PrintQueueAndTotalMailCount:
+	push af
+	push bc
+	push de
+	push hl
+	ld a, [wNumMailInQueue]
+	ld l, a
+	ld h, $00
+	ld a, 2
+	ld b, FALSE
+	lb de, 14, 1
+	call PrintNumber
+	ld a, [wMailCount]
+	ld l, a
+	ld h, $00
+	ld a, 2
+	ld b, FALSE
+	lb de, 17, 1
+	call PrintNumber
+	pop hl
+	pop de
+	pop bc
+	pop af
+	ret
 
 MinicomMailboxMainScreen:
 	call DisableLCD
@@ -6509,9 +6531,12 @@ ScrollMailboxPageOnPadUp:
 	call SetMenuBoxFocusedItem
 	call SetMenuBoxBoundaryNoOpFlag
 	ret
-; 0x1ef9a
 
-SECTION "Bank 7@6fa4", ROMX[$6fa4], BANK[$7]
+HandleSelectedMailMenu_Simple:
+	call MailboxSelectedMail_LoadMenuBoxParams
+	call MailboxSelectedMail_HandleMenuBox
+	call MailboxSelectedMail_CallMappedFunction
+	ret
 
 MailboxSelectedMail_LoadMenuBoxParams:
 	lb de, 0, 0

--- a/src/home/unsorted.asm
+++ b/src/home/unsorted.asm
@@ -2060,12 +2060,13 @@ LoadPortraitPalettes::
 	pop af
 	ret
 
-Func_3b14::
-	farcall $7, $4379
+SaveAndApplyNewTextBoxFrameColor_2::
+	farcall _SaveAndApplyNewTextBoxFrameColor_2
 	ret
 
-Func_3b19::
-	farcall $7, $445a
+; this is the one actually in use, not the above one
+SaveAndApplyNewTextBoxFrameColor::
+	farcall _SaveAndApplyNewTextBoxFrameColor
 	ret
 
 SaveGame::

--- a/src/home/unsorted.asm
+++ b/src/home/unsorted.asm
@@ -1435,57 +1435,58 @@ Func_37ce::
 	ld a, [wd896 + 1]
 	ld b, a
 	or c
-	jr z, .asm_3823
+	jr z, .done
 	farcall CheckPalFading
-	jr nz, .asm_3823
-	farcall $7, $4941
+	jr nz, .done
+	farcall GetwD9DE
 	cp $02
-	jr z, .asm_3823
+	jr z, .done
 	ld a, [wd899]
 	dec a
 	ld [wd899], a
-	jr nz, .asm_3823
+	jr nz, .done
 	ld a, [wd898]
 	ld [wd899], a
+
 	farcall GetPaletteGfxPointer
 	ldh a, [hBankROM]
 	push af
 	ld a, b
 	call BankswitchROM
-	ld a, [hli]
+	ld a, [hli] ; number of pals
 	ld b, a
 	ld a, [wd89a]
 	ld c, a
-	inc a
+	inc a ; next pal
 	cp b
-	jr nz, .asm_3810
+	jr nz, .got_pal_index
 	xor a
-.asm_3810
+.got_pal_index
 	ld [wd89a], a
+REPT 3
 	sla c
-	sla c
-	sla c
+ENDR
 	ld b, $00
 	add hl, bc
-	call Func_3828
+	call .LoadPal
 	pop af
 	call BankswitchROM
-.asm_3823
+.done
 	pop hl
 	pop de
 	pop bc
 	pop af
 	ret
 
-Func_3828::
-	ld de, $cb26
-	ld b, $08
-.asm_382d
+.LoadPal:
+	ld de, wBackgroundPalettesCGB + 7 palettes
+	ld b, PAL_SIZE
+.loop_load
 	ld a, [hli]
 	ld [de], a
 	inc de
 	dec b
-	jr nz, .asm_382d
+	jr nz, .loop_load
 	call FlushAllPalettes
 	ret
 

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -2929,7 +2929,10 @@ wPortraitEmotion:: ; d9cf
 wSelectedConfigSubmenu:: ; d9d0
 	ds $1
 
-	ds $2
+	ds $1
+
+wTempTextBoxFrameColor:: ; d9d2
+	ds $1
 
 ; see also: sDuelAnimationsSetting
 wDuelAnimationsSetting:: ; d9d3
@@ -2945,7 +2948,12 @@ wMessageSpeedSetting:: ; d9d5
 wTextBoxFrameColor:: ; d9d6
 	ds $1
 
-	ds $5
+; this and functions using it are
+; dupes of wTextBoxFrameColor and functions using it
+wTempTextBoxFrameColor_2:: ; d9d7
+	ds $1
+
+	ds $4
 
 wPCMenuCursorPosition:: ; d9dc
 	ds $1

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -2812,6 +2812,7 @@ wScrollTargetSpritePtr:: ; d893
 wOWScrollState:: ; d895
 	ds $1
 
+; PALETTE_* constant
 wd896:: ; d896
 	ds $2
 
@@ -2821,6 +2822,7 @@ wd898:: ; d898
 wd899:: ; d899
 	ds $1
 
+; palette index
 wd89a:: ; d89a
 	ds $1
 

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -2204,9 +2204,7 @@ wNumCardListEntries:: ; d396
 	ds $1
 
 wNamingScreenBuffer:: ; d397
-	ds NAMING_SCREEN_BUFFER_LENGTH
-
-	ds $32
+	ds MULTILINE_INPUT_SCREEN_BUFFER_LENGTH
 
 wNamingScreenBufferLength:: ; d3e1
 	ds $1
@@ -2237,13 +2235,11 @@ wNamingScreenMode:: ; d3eb
 wTempUnnamedDeckCounter:: ; d3ec
 	ds $3
 
-wd3ef:: ; d3ef
+wIsMultilineInput:: ; d3ef
 	ds $1
 
-	ds $1e
-
-wd40e:: ; d40e
-	ds $8
+wCurLineOfMultilineInput:: ; d3f0
+	ds PER_LINE_INPUT_SCREEN_BUFFER_LENGTH
 
 ; pointers to all decks of current deck machine
 wMachineDeckPtrs:: ; d416


### PR DESCRIPTION
- Find:
  - Bank 6: text input handler variants for multiline texts (could be unused)
  - Bank 7: config menu box params, the rest of fade/anim function pairs, and some misc sub-/routines
- Minor cleanups

Also complete the two banks.
